### PR TITLE
Optimize buffer parsing and fix test server

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -68,31 +68,14 @@ func (b *Buffer) parseEntries(data []byte) []codec.LogEntry {
 	buf := data
 
 	for len(buf) > 0 {
-		// Try to parse the current entry
 		entry := codec.LogEntry(buf)
-		sequenceID := entry.ID()
-		text := entry.Text()
-		actors := entry.Actors()
-
-		// Check if parsing was successful
-		if sequenceID == 0 && len(text) == 0 && len(actors) == 0 {
-			break // End of valid data
-		}
-
-		// Re-encode to get the exact size
-		reconstructed, err := codec.NewLogEntry(sequenceID, text, actors)
-		if err != nil {
+		size := int(entry.Size())
+		if size == 0 || size > len(buf) {
 			break
 		}
 
-		entrySize := len(reconstructed)
-		if len(buf) < entrySize {
-			break
-		}
-
-		// Extract the entry
-		entries = append(entries, codec.LogEntry(buf[:entrySize]))
-		buf = buf[entrySize:]
+		entries = append(entries, entry[:size])
+		buf = buf[size:]
 	}
 
 	return entries

--- a/tales_test.go
+++ b/tales_test.go
@@ -93,7 +93,6 @@ func TestIntegration(t *testing.T) {
 func newService() (*Service, error) {
 	// Create a mock S3 server
 	mockS3 := s3.NewMockS3Server()
-	defer mockS3.Close()
 
 	// Create S3 config for mock server
 	s3Config := s3.CreateConfigForMock(mockS3, "test-bucket", "test-prefix")


### PR DESCRIPTION
## Summary
- avoid needless re-encoding when parsing buffer entries
- keep mock S3 server alive during tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c161f24608322b4d9b017bbf8106c