### PR TITLE
Use iter.Seq in Buffer.Query

### DIFF
--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -77,21 +77,35 @@ func TestBuffer_Query(t *testing.T) {
 
 	// Query for actor 10
 	results := buf.Query(10, dayStart, dayStart, dayStart.Add(time.Hour))
-	assert.Len(t, results, 2)
+	count := 0
+	for range results {
+		count++
+	}
+	assert.Equal(t, 2, count)
 
 	// Query for actor 20
 	results = buf.Query(20, dayStart, dayStart, dayStart.Add(time.Hour))
-	assert.Len(t, results, 1)
-	assert.Equal(t, entry1.ID(), results[0].ID())
+	entries := []codec.LogEntry{}
+	for entry := range results {
+		entries = append(entries, entry)
+	}
+	assert.Len(t, entries, 1)
+	assert.Equal(t, entry1.ID(), entries[0].ID())
 
 	// Query for actor 30
 	results = buf.Query(30, dayStart, dayStart, dayStart.Add(time.Hour))
-	assert.Len(t, results, 1)
-	assert.Equal(t, entry2.ID(), results[0].ID())
+	entries = entries[:0]
+	for entry := range results {
+		entries = append(entries, entry)
+	}
+	assert.Len(t, entries, 1)
+	assert.Equal(t, entry2.ID(), entries[0].ID())
 
 	// Query for non-existent actor
 	results = buf.Query(99, dayStart, dayStart, dayStart.Add(time.Hour))
-	assert.Empty(t, results)
+	count = 0
+	for range results {
+		count++
+	}
+	assert.Equal(t, 0, count)
 }
-
-

--- a/tales.go
+++ b/tales.go
@@ -26,7 +26,7 @@ type queryCmd struct {
 	from  time.Time
 	to    time.Time
 	yield func(time.Time, string) bool
-	ret   chan<- []codec.LogEntry
+	ret   chan<- iter.Seq[codec.LogEntry]
 }
 
 // flushCmd represents a command to flush the buffer.

--- a/tales_query.go
+++ b/tales_query.go
@@ -13,11 +13,11 @@ import (
 
 // queryMemory queries the in-memory buffer for entries.
 func (l *Service) queryMemory(actor uint32, from, to time.Time, yield func(time.Time, string) bool) {
-	ret := make(chan []codec.LogEntry, 1)
+	ret := make(chan iter.Seq[codec.LogEntry], 1)
 	l.commands <- queryCmd{actor: actor, from: from, to: to, ret: ret}
 
 	day := seq.DayOf(from)
-	for _, entry := range <-ret {
+	for entry := range <-ret {
 		if !yield(entry.Time(day), entry.Text()) {
 			return
 		}


### PR DESCRIPTION
## Summary
- return `iter.Seq` from `buffer.Buffer.Query` to avoid slice allocations
- adjust service and query logic for new return type
- update buffer unit tests for iterator-based results

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c1afa5e8883228f15387eb57f8094