### PR TITLE
Fix inclusive end of query range

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -68,7 +68,7 @@ func (b *Buffer) Add(entry codec.LogEntry) bool {
 func (b *Buffer) Query(actorID uint32, dayStart time.Time, from, to time.Time) iter.Seq[codec.LogEntry] {
 	return func(yield func(codec.LogEntry) bool) {
 		t0 := asSequence(from.UTC(), dayStart)
-		t1 := asSequence(to.UTC(), dayStart)
+		t1 := asSequence(to.UTC(), dayStart) | counterMask
 
 		for buffer := b.data; len(buffer) > 0; {
 			entry := codec.LogEntry(buffer)
@@ -170,6 +170,8 @@ func (b *Buffer) reset() {
 }
 
 // asSequence converts a time to a sequence ID for range queries.
+const counterMask = (1 << 20) - 1
+
 func asSequence(t, dayStart time.Time) uint32 {
 	return uint32(t.Sub(dayStart).Minutes()) << 20
 }

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kelindar/threads/internal/codec"
+	"github.com/kelindar/threads/internal/seq"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,4 +109,23 @@ func TestBuffer_Query(t *testing.T) {
 		count++
 	}
 	assert.Equal(t, 0, count)
+}
+
+func TestBuffer_QueryInclusiveTo(t *testing.T) {
+	c, _ := codec.NewCodec()
+	buf := New(10, c)
+	dayStart := time.Now().UTC().Truncate(24 * time.Hour)
+	sg := seq.NewSequence(dayStart)
+
+	ts := dayStart.Add(10*time.Minute + 30*time.Second)
+	id := sg.Next(ts)
+	entry, _ := codec.NewLogEntry(id, "test", []uint32{1})
+	buf.Add(entry)
+
+	results := buf.Query(1, dayStart, dayStart, ts)
+	count := 0
+	for range results {
+		count++
+	}
+	assert.Equal(t, 1, count)
 }


### PR DESCRIPTION
## Summary
- ensure memory buffer query includes all entries up to the end time
- test inclusive query behavior for entries at the upper bound

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c20f14d108322a82b6244bbeb421a