### PR TITLE
Fix inclusive bounds in S3 query

### DIFF
--- a/tales_query.go
+++ b/tales_query.go
@@ -178,7 +178,7 @@ func (l *Service) queryChunk(ctx context.Context, logKey string, chunk codec.Chu
 		}
 
 		ts := seq.TimeOf(id, day)
-		if ts.After(from) && ts.Before(to) && !yield(ts, entry.Text()) {
+		if !ts.Before(from) && !ts.After(to) && !yield(ts, entry.Text()) {
 			return false // Stop iteration
 		}
 	}


### PR DESCRIPTION
## Summary
- fix `queryChunk` so historical queries include `from` and `to` timestamps

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c3e1660f48322b0dfeaf486eb0852