### PR TITLE
Fix LogEntry timestamp conversion

### DIFF
--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -3,6 +3,8 @@ package codec
 import (
 	"encoding/binary"
 	"time"
+
+	"github.com/kelindar/threads/internal/seq"
 )
 
 const (
@@ -54,7 +56,7 @@ func NewLogEntry(sequenceID uint32, text string, actors []uint32) (LogEntry, err
 // ID extracts the sequence ID from a log entry
 // Time reconstructs the timestamp from the day-start and sequence ID.
 func (e LogEntry) Time(dayStart time.Time) time.Time {
-	return dayStart.Add(time.Duration(e.ID()) * time.Second)
+	return seq.TimeOf(e.ID(), dayStart)
 }
 
 // ID extracts the sequence ID from a log entry


### PR DESCRIPTION
## Summary
- fix `LogEntry.Time` to reconstruct timestamps correctly using the sequence ID

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c3f7d4f4083229cd52ba873831479