### PR TITLE
Refine config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ type Logger struct {
     // private implementation
 }
 
-func New(config Config) (*Logger, error)
+func New(cfg S3Config, opts ...Option) (*Logger, error)
 func (l *Logger) Log(text string, actors []uint32) error
 func (l *Logger) Query(actor uint32, from, to time.Time) iter.Seq2[time.Time, string]
 func (l *Logger) Close() error
@@ -188,6 +188,22 @@ type S3Config struct {
 }
 ```
 
+If `Bucket` or `Region` are omitted, they are resolved from the environment
+variables `S3_BUCKET`, `AWS_REGION`, or `AWS_DEFAULT_REGION`.
+
+The logger is created by providing the required S3 configuration and optional
+settings:
+
+```go
+logger, err := threads.New(
+    threads.S3Config{
+        Bucket: "game-logs-bucket",
+        Region: "us-west-2",
+    },
+    threads.WithChunkInterval(5*time.Minute),
+)
+```
+
 ## S3 Access Patterns
 
 ### Byte-Range Operations
@@ -252,14 +268,14 @@ import (
 
 ### Basic Setup and Logging
 ```go
-logger, err := threads.New(threads.Config{
-    S3Config: threads.S3Config{
+logger, err := threads.New(
+    threads.S3Config{
         Bucket: "game-logs-bucket",
         Region: "us-west-2",
         Prefix: "production/threads/",
     },
-    ChunkInterval: 5 * time.Minute,
-})
+    threads.WithChunkInterval(5 * time.Minute),
+)
 if err != nil {
     return err
 }

--- a/example_test.go
+++ b/example_test.go
@@ -4,25 +4,20 @@ import (
 	"fmt"
 	"log"
 	"time"
-
-	"github.com/kelindar/threads/internal/s3"
 )
 
 // Example demonstrates basic usage of the threads library
 func Example() {
-	// Configure the logger
-	config := Config{
-		S3Config: s3.Config{
+	// Create logger
+	logger, err := New(
+		S3Config{
 			Bucket: "my-game-logs",
 			Region: "us-east-1",
 			Prefix: "game-events",
 		},
-		ChunkInterval: 5 * time.Minute,
-		BufferSize:    1000,
-	}
-
-	// Create logger
-	logger, err := New(config)
+		WithChunkInterval(5*time.Minute),
+		WithBufferSize(1000),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tales_config.go
+++ b/tales_config.go
@@ -3,17 +3,52 @@ package threads
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/kelindar/threads/internal/s3"
 )
 
+// Option configures optional parameters for the logger service.
+type Option func(*Config)
+
+// S3Config holds S3 configuration parameters used by the service.
+type S3Config struct {
+	Bucket      string // S3 bucket name
+	Region      string // AWS region
+	Prefix      string // Key prefix
+	Concurrency int    // Max concurrent S3 requests (default: 10)
+	Retries     int    // Retry attempts for failed requests (default: 3)
+}
+
+// toInternal converts the public S3Config to the internal representation.
+func (c S3Config) toInternal() s3.Config {
+	return s3.Config{
+		Bucket:      c.Bucket,
+		Region:      c.Region,
+		Prefix:      c.Prefix,
+		Concurrency: c.Concurrency,
+		Retries:     c.Retries,
+	}
+}
+
 // Config represents the configuration for the threads logger.
 type Config struct {
-	S3Config      s3.Config     // S3 configuration (required)
+	S3Config      S3Config      // S3 configuration (required)
 	ChunkInterval time.Duration // Chunk completion interval (default: 5 minutes)
 	BufferSize    int           // Memory buffer size (default: 1000 entries)
-	NewS3Client   func(context.Context, s3.Config) (s3.Client, error)
+	NewS3Client   func(context.Context, S3Config) (s3.Client, error)
+}
+
+// WithChunkInterval sets the chunk interval.
+func WithChunkInterval(d time.Duration) Option { return func(c *Config) { c.ChunkInterval = d } }
+
+// WithBufferSize sets the memory buffer size.
+func WithBufferSize(size int) Option { return func(c *Config) { c.BufferSize = size } }
+
+// WithS3Client overrides the S3 client creation function.
+func WithS3Client(fn func(context.Context, S3Config) (s3.Client, error)) Option {
+	return func(c *Config) { c.NewS3Client = fn }
 }
 
 // setDefaults applies default values to the configuration.
@@ -29,6 +64,18 @@ func (c *Config) setDefaults() {
 	}
 	if c.S3Config.Retries == 0 {
 		c.S3Config.Retries = 3
+	}
+	if c.S3Config.Region == "" {
+		if v := os.Getenv("AWS_REGION"); v != "" {
+			c.S3Config.Region = v
+		} else if v := os.Getenv("AWS_DEFAULT_REGION"); v != "" {
+			c.S3Config.Region = v
+		}
+	}
+	if c.S3Config.Bucket == "" {
+		if v := os.Getenv("S3_BUCKET"); v != "" {
+			c.S3Config.Bucket = v
+		}
 	}
 }
 

--- a/tales_options_test.go
+++ b/tales_options_test.go
@@ -1,0 +1,45 @@
+package threads
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kelindar/threads/internal/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that defaults are applied when options are not provided
+func TestOptionsDefaults(t *testing.T) {
+	cfg := S3Config{Bucket: "b", Region: "r"}
+	svc, err := New(cfg)
+	assert.NoError(t, err)
+	defer svc.Close()
+
+	assert.Equal(t, 5*time.Minute, svc.config.ChunkInterval)
+	assert.Equal(t, 1000, svc.config.BufferSize)
+	assert.Equal(t, 10, svc.config.S3Config.Concurrency)
+	assert.Equal(t, 3, svc.config.S3Config.Retries)
+}
+
+// Test that options override defaults
+func TestOptionsOverride(t *testing.T) {
+	cfg := S3Config{Bucket: "b", Region: "r"}
+	var called bool
+	custom := func(ctx context.Context, c S3Config) (s3.Client, error) {
+		called = true
+		return s3.NewMockClient(ctx, s3.NewMockS3Server(), c.toInternal())
+	}
+	svc, err := New(
+		cfg,
+		WithChunkInterval(2*time.Minute),
+		WithBufferSize(42),
+		WithS3Client(custom),
+	)
+	assert.NoError(t, err)
+	defer svc.Close()
+
+	assert.Equal(t, 2*time.Minute, svc.config.ChunkInterval)
+	assert.Equal(t, 42, svc.config.BufferSize)
+	assert.True(t, called)
+}


### PR DESCRIPTION
## Summary
- rework logger construction to take S3Config as a required argument
- remove `WithS3Config` option
- update docs and examples for the new API
- adjust tests to match

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c404f8b9083228e14cfc406ff330e