### PR TITLE
Refactor config to options pattern

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -16,17 +16,17 @@ func Example() {
 	mockServer := s3mock.New("example-bucket", "us-east-1")
 	defer mockServer.Close()
 
-	config := Config{
-		S3Config:      s3.CreateConfigForMock(mockServer, "example-bucket", "events"),
-		ChunkInterval: 5 * time.Minute,
-		BufferSize:    1000,
-		NewS3Client: func(ctx context.Context, cfg s3.Config) (s3.Client, error) {
-			return s3.NewMockClient(ctx, mockServer, cfg)
-		},
-	}
-
 	// Create logger
-	logger, err := New(config)
+	logger, err := New(
+		"example-bucket",
+		"us-east-1",
+		WithPrefix("events"),
+		WithChunkInterval(5*time.Minute),
+		WithBufferSize(1000),
+		WithS3Client(func(ctx context.Context, cfg s3.Config) (s3.Client, error) {
+			return s3.NewMockClient(ctx, mockServer, cfg)
+		}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tales_test.go
+++ b/tales_test.go
@@ -96,18 +96,14 @@ func newService() (*Service, error) {
 	// Create a mock S3 server
 	mockS3 := s3mock.New("test-bucket", "us-east-1")
 
-	// Create S3 config for mock server
-	s3Config := s3.CreateConfigForMock(mockS3, "test-bucket", "test-prefix")
-
-	// Create logger config
-	config := Config{
-		ChunkInterval: 1 * time.Minute,
-		BufferSize:    1024 * 1024, // 1MB
-		S3Config:      s3Config,
-		NewS3Client: func(ctx context.Context, config s3.Config) (s3.Client, error) {
+	return New(
+		"test-bucket",
+		"us-east-1",
+		WithPrefix("test-prefix"),
+		WithChunkInterval(1*time.Minute),
+		WithBufferSize(1024*1024),
+		WithS3Client(func(ctx context.Context, config s3.Config) (s3.Client, error) {
 			return s3.NewMockClient(ctx, mockS3, config)
-		},
-	}
-
-	return New(config)
+		}),
+	)
 }


### PR DESCRIPTION
## Summary
- switch to functional options for configuring the service
- keep required params as normal arguments

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d12ea918c8322b99bf4a8ba67d313