### PR TITLE
Simplify option names

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 		WithPrefix("events"),
 		WithChunkInterval(5*time.Minute),
 		WithBufferSize(1000),
-		WithS3Client(func(ctx context.Context, cfg s3.Config) (s3.Client, error) {
+		WithClient(func(ctx context.Context, cfg s3.Config) (s3.Client, error) {
 			return s3.NewMockClient(ctx, mockServer, cfg)
 		}),
 	)

--- a/tales.go
+++ b/tales.go
@@ -67,8 +67,8 @@ func New(bucket, region string, opts ...Option) (*Service, error) {
 
 	// Create S3 client
 	var s3Client s3.Client
-	if cfg.NewS3Client != nil {
-		s3Client, err = cfg.NewS3Client(context.Background(), cfg.S3Config)
+	if cfg.NewClient != nil {
+		s3Client, err = cfg.NewClient(context.Background(), cfg.S3Config)
 	} else {
 		s3Client, err = s3.NewClient(context.Background(), cfg.S3Config)
 	}

--- a/tales_config.go
+++ b/tales_config.go
@@ -27,19 +27,19 @@ func WithPrefix(prefix string) Option {
 	return func(c *config) { c.S3Config.Prefix = prefix }
 }
 
-// WithS3Concurrency sets the (unused) concurrency parameter on the S3 config.
-func WithS3Concurrency(n int) Option {
+// WithConcurrency sets the (unused) concurrency parameter on the S3 config.
+func WithConcurrency(n int) Option {
 	return func(c *config) { c.S3Config.Concurrency = n }
 }
 
-// WithS3Retries sets the (unused) retries parameter on the S3 config.
-func WithS3Retries(n int) Option {
+// WithRetries sets the (unused) retries parameter on the S3 config.
+func WithRetries(n int) Option {
 	return func(c *config) { c.S3Config.Retries = n }
 }
 
-// WithS3Client allows overriding the S3 client creation function.
-func WithS3Client(fn func(context.Context, s3.Config) (s3.Client, error)) Option {
-	return func(c *config) { c.NewS3Client = fn }
+// WithClient allows overriding the S3 client creation function.
+func WithClient(fn func(context.Context, s3.Config) (s3.Client, error)) Option {
+	return func(c *config) { c.NewClient = fn }
 }
 
 // config holds all configuration for the logger. It is kept private and
@@ -48,7 +48,7 @@ type config struct {
 	S3Config      s3.Config
 	ChunkInterval time.Duration
 	BufferSize    int
-	NewS3Client   func(context.Context, s3.Config) (s3.Client, error)
+	NewClient     func(context.Context, s3.Config) (s3.Client, error)
 }
 
 // setDefaults applies default values to the configuration.

--- a/tales_test.go
+++ b/tales_test.go
@@ -102,7 +102,7 @@ func newService() (*Service, error) {
 		WithPrefix("test-prefix"),
 		WithChunkInterval(1*time.Minute),
 		WithBufferSize(1024*1024),
-		WithS3Client(func(ctx context.Context, config s3.Config) (s3.Client, error) {
+		WithClient(func(ctx context.Context, config s3.Config) (s3.Client, error) {
 			return s3.NewMockClient(ctx, mockS3, config)
 		}),
 	)


### PR DESCRIPTION
## Summary
- rename option helpers to simpler names (WithConcurrency, WithRetries, WithClient)
- update config struct for NewClient field
- adjust tests and examples

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d15f538a48322a3cde2b66f25bb8b