### PR TITLE
Rename threads package to tales

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Threads Library Design Document
+# Tales Library Design Document
 
 ## Overview
 
-The threads library provides high-performance, memory-efficient logging and querying of game events with actor-centric access patterns. It's designed for logging speech and other game events with the ability to query historical data for specific actors.
+The Tales library provides high-performance, memory-efficient logging and querying of game events with actor-centric access patterns. It's designed for logging speech and other game events with the ability to query historical data for specific actors.
 
 ## Core API
 
@@ -318,5 +318,5 @@ for timestamp, text := range logger.Query(12345, from, to) {
 ## Installation
 
 ```bash
-go get github.com/kelindar/threads
+go get github.com/kelindar/tales
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package threads
+package tales
 
 import (
 	"context"
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	s3mock "github.com/kelindar/s3/mock"
-	"github.com/kelindar/threads/internal/s3"
+	"github.com/kelindar/tales/internal/s3"
 )
 
-// Example demonstrates basic usage of the threads library
+// Example demonstrates basic usage of the tales library
 func Example() {
 	// Use a mock S3 server for the example
 	mockServer := s3mock.New("example-bucket", "us-east-1")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kelindar/threads
+module github.com/kelindar/tales
 
 go 1.24.2
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -6,7 +6,7 @@ import (
 	"iter"
 
 	"github.com/RoaringBitmap/roaring/v2"
-	"github.com/kelindar/threads/internal/codec"
+	"github.com/kelindar/tales/internal/codec"
 )
 
 // Buffer represents the in-memory buffer for the current chunk.

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kelindar/threads/internal/codec"
-	"github.com/kelindar/threads/internal/seq"
+	"github.com/kelindar/tales/internal/codec"
+	"github.com/kelindar/tales/internal/seq"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/kelindar/threads/internal/seq"
+	"github.com/kelindar/tales/internal/seq"
 )
 
 const (

--- a/tales.go
+++ b/tales.go
@@ -1,4 +1,4 @@
-package threads
+package tales
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/kelindar/threads/internal/buffer"
-	"github.com/kelindar/threads/internal/codec"
-	"github.com/kelindar/threads/internal/s3"
-	"github.com/kelindar/threads/internal/seq"
+	"github.com/kelindar/tales/internal/buffer"
+	"github.com/kelindar/tales/internal/codec"
+	"github.com/kelindar/tales/internal/s3"
+	"github.com/kelindar/tales/internal/seq"
 )
 
 // logCmd represents a command to log an entry.

--- a/tales_config.go
+++ b/tales_config.go
@@ -1,11 +1,11 @@
-package threads
+package tales
 
 import (
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/kelindar/threads/internal/s3"
+	"github.com/kelindar/tales/internal/s3"
 )
 
 // Option configures the Service. All options are optional and may be provided

--- a/tales_flush.go
+++ b/tales_flush.go
@@ -1,14 +1,14 @@
-package threads
+package tales
 
 import (
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/kelindar/threads/internal/buffer"
-	"github.com/kelindar/threads/internal/codec"
-	"github.com/kelindar/threads/internal/s3"
-	"github.com/kelindar/threads/internal/seq"
+	"github.com/kelindar/tales/internal/buffer"
+	"github.com/kelindar/tales/internal/codec"
+	"github.com/kelindar/tales/internal/s3"
+	"github.com/kelindar/tales/internal/seq"
 )
 
 // flushBuffer flushes the current buffer to S3 using a separate metadata file.

--- a/tales_query.go
+++ b/tales_query.go
@@ -1,4 +1,4 @@
-package threads
+package tales
 
 import (
 	"context"
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
-	"github.com/kelindar/threads/internal/codec"
-	"github.com/kelindar/threads/internal/seq"
+	"github.com/kelindar/tales/internal/codec"
+	"github.com/kelindar/tales/internal/seq"
 )
 
 // queryMemory queries the in-memory buffer for entries.

--- a/tales_test.go
+++ b/tales_test.go
@@ -1,4 +1,4 @@
-package threads
+package tales
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	s3mock "github.com/kelindar/s3/mock"
-	"github.com/kelindar/threads/internal/s3"
+	"github.com/kelindar/tales/internal/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary
- rename `threads` package to `tales`
- update import paths and go module
- refresh docs and examples with the new package name

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d1c4089e88322aad06f03e09868cc