### PR TITLE
Remove unused fields and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ type S3Config struct {
     Bucket          string
     Region          string
     Prefix          string
-    Concurrency     int    // Unused, kept for compatibility
     Retries         int    // Unused, kept for compatibility
     // AWS credentials via environment or IAM roles
 }

--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	TailMagic      = "TAIL"
 	ChunkEntrySize = 16 // 8 bytes offset + 4 bytes compressed size + 4 bytes uncompressed size
 	IndexEntrySize = 24 // 4 bytes timestamp + 4 bytes actor_id + 8 bytes offset + 4 bytes compressed size + 4 bytes uncompressed size
 )

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -170,7 +170,4 @@ func TestConstants(t *testing.T) {
 		assert.Equal(t, 24, IndexEntrySize)
 	})
 
-	t.Run("Magic", func(t *testing.T) {
-		assert.Equal(t, "TAIL", TailMagic)
-	})
 }

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -14,11 +14,10 @@ import (
 
 // Config represents the S3-specific configuration.
 type Config struct {
-	Bucket      string // S3 bucket name (required)
-	Region      string // AWS region (required for mock)
-	Prefix      string // S3 key prefix (optional)
-	Concurrency int    // Unused but kept for compatibility
-	Retries     int    // Unused but kept for compatibility
+	Bucket  string // S3 bucket name (required)
+	Region  string // AWS region (required for mock)
+	Prefix  string // S3 key prefix (optional)
+	Retries int    // Unused but kept for compatibility
 }
 
 // Client interface abstracts S3 operations for easier testing and mocking

--- a/internal/seq/sequence.go
+++ b/internal/seq/sequence.go
@@ -7,11 +7,9 @@ import (
 
 const (
 	// Sequence ID format constants
-	minuteBits  = 12                     // High 12 bits for minutes (0-1439)
 	counterBits = 20                     // Low 20 bits for counter (0-1048575)
 	counterMask = (1 << counterBits) - 1 // 0xFFFFF
 	maxMinutes  = 1439                   // Maximum minutes in a day (24*60-1)
-	maxCounter  = (1 << counterBits) - 1 // Maximum counter value
 )
 
 // Sequence generates unique Sequence IDs for a specific day.

--- a/tales.go
+++ b/tales.go
@@ -25,7 +25,6 @@ type queryCmd struct {
 	actor uint32
 	from  time.Time
 	to    time.Time
-	yield func(time.Time, string) bool
 	ret   chan<- iter.Seq[codec.LogEntry]
 }
 

--- a/tales_config.go
+++ b/tales_config.go
@@ -27,11 +27,6 @@ func WithPrefix(prefix string) Option {
 	return func(c *config) { c.S3Config.Prefix = prefix }
 }
 
-// WithConcurrency sets the (unused) concurrency parameter on the S3 config.
-func WithConcurrency(n int) Option {
-	return func(c *config) { c.S3Config.Concurrency = n }
-}
-
 // WithRetries sets the (unused) retries parameter on the S3 config.
 func WithRetries(n int) Option {
 	return func(c *config) { c.S3Config.Retries = n }
@@ -58,9 +53,6 @@ func (c *config) setDefaults() {
 	}
 	if c.BufferSize == 0 {
 		c.BufferSize = 1000
-	}
-	if c.S3Config.Concurrency == 0 {
-		c.S3Config.Concurrency = 10
 	}
 	if c.S3Config.Retries == 0 {
 		c.S3Config.Retries = 3


### PR DESCRIPTION
## Summary
- delete unused `yield` field from `queryCmd`
- delete unused `TailMagic` constant and related test
- drop unused S3 config field `Concurrency`
- keep `Retries` option for backward compatibility
- simplify sequence constants
- update README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d2008e8088322a615a48f07fb2f9f