### PR TITLE
Refactor key creation helper

### DIFF
--- a/tales_flush.go
+++ b/tales_flush.go
@@ -32,10 +32,7 @@ func (l *Service) flushBuffer(ctx context.Context, buf *buffer.Buffer) error {
 	date := seq.FormatDate(now)
 	flushTimeMinutes := uint32(now.Sub(day).Minutes())
 
-	tlog := fmt.Sprintf("%s/threads.log", date)
-	tidx := fmt.Sprintf("%s/threads.idx", date)
-	alog := fmt.Sprintf("%s/actors.log", date)
-	aidx := fmt.Sprintf("%s/actors.idx", date)
+	tlog, tidx, alog, aidx := buildDailyKeys(date)
 
 	// 1. Read existing metadata file.
 	var meta *codec.Metadata

--- a/tales_keys.go
+++ b/tales_keys.go
@@ -1,0 +1,12 @@
+package tales
+
+import "fmt"
+
+// buildDailyKeys builds S3 object keys for the provided date (YYYY-MM-DD).
+func buildDailyKeys(date string) (threadsLog, threadsIdx, actorsLog, actorsIdx string) {
+	threadsLog = fmt.Sprintf("%s/threads.log", date)
+	threadsIdx = fmt.Sprintf("%s/threads.idx", date)
+	actorsLog = fmt.Sprintf("%s/actors.log", date)
+	actorsIdx = fmt.Sprintf("%s/actors.idx", date)
+	return
+}

--- a/tales_query.go
+++ b/tales_query.go
@@ -43,10 +43,7 @@ func (l *Service) queryDay(ctx context.Context, actor uint32, day time.Time, fro
 	date := seq.FormatDate(day)
 
 	// Build S3 keys
-	tlog := fmt.Sprintf("%s/threads.log", date)
-	tidx := fmt.Sprintf("%s/threads.idx", date)
-	alog := fmt.Sprintf("%s/actors.log", date)
-	aidx := fmt.Sprintf("%s/actors.idx", date)
+	tlog, tidx, alog, aidx := buildDailyKeys(date)
 
 	// 1. Download and parse index file
 	entries, err := l.loadIndexFile(ctx, aidx)

--- a/tales_test.go
+++ b/tales_test.go
@@ -92,6 +92,14 @@ func TestIntegration(t *testing.T) {
 	assert.Empty(t, results4)
 }
 
+func TestBuildDailyKeys(t *testing.T) {
+	tlog, tidx, alog, aidx := buildDailyKeys("2023-01-02")
+	assert.Equal(t, "2023-01-02/threads.log", tlog)
+	assert.Equal(t, "2023-01-02/threads.idx", tidx)
+	assert.Equal(t, "2023-01-02/actors.log", alog)
+	assert.Equal(t, "2023-01-02/actors.idx", aidx)
+}
+
 func newService() (*Service, error) {
 	// Create a mock S3 server
 	mockS3 := s3mock.New("test-bucket", "us-east-1")


### PR DESCRIPTION
## Summary
- refactor S3 key creation into `buildDailyKeys`
- use helper in flush and query paths
- add unit test for key builder

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d577f4154832291151dd26b6109aa