### PR TITLE
Refactor command channel for typed pointers

### DIFF
--- a/tales_query.go
+++ b/tales_query.go
@@ -14,7 +14,7 @@ import (
 // queryMemory queries the in-memory buffer for entries.
 func (l *Service) queryMemory(actor uint32, from, to time.Time, yield func(time.Time, string) bool) {
 	ret := make(chan iter.Seq[codec.LogEntry], 1)
-	l.commands <- queryCmd{actor: actor, from: from, to: to, ret: ret}
+	l.commands <- command{query: &queryCmd{actor: actor, from: from, to: to, ret: ret}}
 
 	day := seq.DayOf(from)
 	for entry := range <-ret {


### PR DESCRIPTION
## Summary
- switch command channel to typed `command` struct holding pointer fields
- represent log commands as `codec.LogEntry`
- update run loop and helpers to use typed commands

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d600a723c83229d04314054059055