### PR TITLE
Remove S3 append logic

### DIFF
--- a/internal/codec/meta.go
+++ b/internal/codec/meta.go
@@ -7,12 +7,9 @@ import (
 
 // Metadata represents the metadata structure for log files.
 type Metadata struct {
-	DayStart        int64        `json:"day_start"`
-	ChunkCount      uint32       `json:"chunk_count"`
-	Chunks          []ChunkEntry `json:"chunks"`
-	Size            uint32       `json:"tail_size"`
-	TotalDataSize   uint32       `json:"total_data_size"`
-	TotalBitmapSize uint32       `json:"total_bitmap_size"`
+	DayStart   int64        `json:"day_start"`
+	ChunkCount uint32       `json:"chunk_count"`
+	Chunks     []ChunkEntry `json:"chunks"`
 }
 
 // NewMetadata creates a new metadata instance with default values.
@@ -37,10 +34,8 @@ func DecodeMetadata(data []byte) (*Metadata, error) {
 }
 
 // Update adds a new chunk and updates bitmap size.
-func (m *Metadata) Update(offset uint64, compressedSize, uncompressedSize, bitmapSize uint32) {
+func (m *Metadata) Update(offset uint64, compressedSize, uncompressedSize uint32) {
 	newChunk := NewChunkEntry(offset, compressedSize, uncompressedSize)
 	m.Chunks = append(m.Chunks, newChunk)
-	m.TotalDataSize += compressedSize
 	m.ChunkCount = uint32(len(m.Chunks))
-	m.TotalBitmapSize = bitmapSize
 }

--- a/internal/codec/meta_test.go
+++ b/internal/codec/meta_test.go
@@ -16,18 +16,14 @@ func TestMetadata(t *testing.T) {
 		assert.Equal(t, dayStart.UnixNano(), meta.DayStart)
 		assert.Equal(t, uint32(0), meta.ChunkCount)
 		assert.Empty(t, meta.Chunks)
-		assert.Equal(t, uint32(0), meta.TotalDataSize)
-		assert.Equal(t, uint32(0), meta.TotalBitmapSize)
 	})
 
 	t.Run("Update", func(t *testing.T) {
 		meta := NewMetadata(time.Now())
 
 		// Add first chunk
-		meta.Update(0, 100, 200, 512)
+		meta.Update(0, 100, 200)
 		assert.Equal(t, uint32(1), meta.ChunkCount)
-		assert.Equal(t, uint32(100), meta.TotalDataSize)
-		assert.Equal(t, uint32(512), meta.TotalBitmapSize)
 		assert.Len(t, meta.Chunks, 1)
 
 		// Verify chunk data
@@ -37,10 +33,8 @@ func TestMetadata(t *testing.T) {
 		assert.Equal(t, uint32(200), chunk.UncompressedSize())
 
 		// Add second chunk
-		meta.Update(100, 150, 300, 1024)
+		meta.Update(1, 150, 300)
 		assert.Equal(t, uint32(2), meta.ChunkCount)
-		assert.Equal(t, uint32(250), meta.TotalDataSize)
-		assert.Equal(t, uint32(1024), meta.TotalBitmapSize)
 		assert.Len(t, meta.Chunks, 2)
 	})
 
@@ -48,9 +42,8 @@ func TestMetadata(t *testing.T) {
 		// Create metadata with some data
 		dayStart := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
 		original := NewMetadata(dayStart)
-		original.Update(0, 100, 200, 256)
-		original.Update(100, 150, 300, 512)
-		original.Size = 1024
+		original.Update(0, 100, 200)
+		original.Update(1, 150, 300)
 
 		// Encode to JSON
 		encoded, err := EncodeMetadata(original)
@@ -68,9 +61,6 @@ func TestMetadata(t *testing.T) {
 		// Verify all fields match
 		assert.Equal(t, original.DayStart, decoded.DayStart)
 		assert.Equal(t, original.ChunkCount, decoded.ChunkCount)
-		assert.Equal(t, original.Size, decoded.Size)
-		assert.Equal(t, original.TotalDataSize, decoded.TotalDataSize)
-		assert.Equal(t, original.TotalBitmapSize, decoded.TotalBitmapSize)
 		assert.Len(t, decoded.Chunks, len(original.Chunks))
 
 		// Verify chunks

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -1,336 +1,52 @@
 package s3
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"io/fs"
 	"testing"
 
-	s3lib "github.com/kelindar/s3"
 	s3mock "github.com/kelindar/s3/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestS3ClientWithMock(t *testing.T) {
-	// Start mock S3 server
-	mockServer := s3mock.New("test-bucket", "us-east-1")
-	defer mockServer.Close()
+func TestS3ClientBasics(t *testing.T) {
+	server := s3mock.New("test-bucket", "us-east-1")
+	defer server.Close()
 
-	// Create S3 config for mock
-	config := CreateConfigForMock(mockServer, "test-bucket", "test-prefix")
-
-	// Create S3 client that connects to mock server
-	client, err := NewMockClient(context.Background(), mockServer, config)
+	cfg := CreateConfigForMock(server, "test-bucket", "test")
+	client, err := NewMockClient(context.Background(), server, cfg)
 	require.NoError(t, err)
 
-	t.Run("UploadAndDownload", func(t *testing.T) {
-		ctx := context.Background()
-		key := "test-file.txt"
-		data := []byte("Hello, S3!")
+	ctx := context.Background()
+	key := "file.txt"
+	data := []byte("hello world")
 
-		// Upload data
-		err := client.Append(ctx, key, data)
-		assert.NoError(t, err)
+	// Upload and download
+	err = client.Upload(ctx, key, data)
+	require.NoError(t, err)
 
-		// Verify it exists in mock server
-		storedData, exists := mockServer.ObjectContent("test-prefix/" + key)
-		assert.True(t, exists)
-		assert.Equal(t, data, storedData)
+	out, err := client.Download(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, data, out)
 
-		// Download data back
-		downloadedData, err := client.Download(ctx, key)
-		assert.NoError(t, err)
-		assert.Equal(t, data, downloadedData)
-	})
+	// Range
+	part, err := client.DownloadRange(ctx, key, 0, int64(len(data))-1)
+	require.NoError(t, err)
+	assert.Equal(t, data, part)
 
-	t.Run("AppendData", func(t *testing.T) {
-		ctx := context.Background()
-		key := "append-test.txt"
+	// Exists
+	exists, err := client.ObjectExists(ctx, key)
+	require.NoError(t, err)
+	assert.True(t, exists)
 
-		// First upload
-		data1 := []byte("First part")
-		err := client.Append(ctx, key, data1)
-		assert.NoError(t, err)
-
-		// Append more data
-		data2 := []byte(" Second part")
-		err = client.Append(ctx, key, data2)
-		assert.NoError(t, err)
-
-		// Download and verify combined data
-		combined, err := client.Download(ctx, key)
-		assert.NoError(t, err)
-		assert.Equal(t, "First part Second part", string(combined))
-	})
-
-	t.Run("AppendToNonExistentFile", func(t *testing.T) {
-		ctx := context.Background()
-		key := "new-file.txt"
-		data := []byte("New file content")
-
-		// Append to non-existent file should create it
-		err := client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Verify file was created
-		downloaded, err := client.Download(ctx, key)
-		assert.NoError(t, err)
-		assert.Equal(t, data, downloaded)
-	})
-
-	t.Run("AppendLargeObject", func(t *testing.T) {
-		ctx := context.Background()
-		key := "large-file.bin"
-		large := bytes.Repeat([]byte("A"), s3lib.MinPartSize+1024)
-
-		// Upload a large object first
-		err := client.Append(ctx, key, large)
-		require.NoError(t, err)
-
-		// Append a small chunk
-		small := bytes.Repeat([]byte("B"), 1024)
-		err = client.Append(ctx, key, small)
-		require.NoError(t, err)
-
-		// Verify size and content
-		combined, err := client.Download(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, len(large)+len(small), len(combined))
-		assert.Equal(t, large, combined[:len(large)])
-		assert.Equal(t, small, combined[len(large):])
-	})
-
-	t.Run("DownloadRange", func(t *testing.T) {
-		ctx := context.Background()
-		key := "range-test.txt"
-		data := []byte("0123456789ABCDEF")
-
-		// Upload test data
-		err := client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Download range (bytes 5-9)
-		rangeData, err := client.DownloadRange(ctx, key, 5, 9)
-		assert.NoError(t, err)
-		assert.Equal(t, "56789", string(rangeData))
-
-		// Download range from start
-		rangeData, err = client.DownloadRange(ctx, key, 0, 4)
-		assert.NoError(t, err)
-		assert.Equal(t, "01234", string(rangeData))
-
-		// Download range to end
-		rangeData, err = client.DownloadRange(ctx, key, 12, 15)
-		assert.NoError(t, err)
-		assert.Equal(t, "CDEF", string(rangeData))
-	})
-
-	t.Run("ObjectExists", func(t *testing.T) {
-		ctx := context.Background()
-		existingKey := "existing-file.txt"
-		nonExistentKey := "non-existent-file.txt"
-
-		// Upload a file
-		err := client.Append(ctx, existingKey, []byte("test"))
-		assert.NoError(t, err)
-
-		// Check existing file
-		exists, err := client.ObjectExists(ctx, existingKey)
-		assert.NoError(t, err)
-		assert.True(t, exists)
-
-		// Check non-existent file
-		exists, err = client.ObjectExists(ctx, nonExistentKey)
-		assert.NoError(t, err)
-		assert.False(t, exists)
-	})
-
-	t.Run("GetObjectSize", func(t *testing.T) {
-		ctx := context.Background()
-		key := "size-test.txt"
-		data := []byte("This file has exactly 32 chars!")
-
-		// Upload test data
-		err := client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Get object size
-		size, err := client.ObjectSize(ctx, key)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(len(data)), size)
-		assert.Greater(t, size, int64(0)) // Should be positive
-	})
-
-	t.Run("DownloadNonExistentFile", func(t *testing.T) {
-		ctx := context.Background()
-		key := "does-not-exist.txt"
-
-		// Try to download non-existent file
-		_, err := client.Download(ctx, key)
-		assert.Error(t, err)
-
-		// Should be an S3 operation error
-		var s3Err ErrS3Operation
-		assert.ErrorAs(t, err, &s3Err)
-		assert.Equal(t, "download", s3Err.Operation)
-	})
-
-	t.Run("GetSizeOfNonExistentFile", func(t *testing.T) {
-		ctx := context.Background()
-		key := "does-not-exist.txt"
-
-		// Try to get size of non-existent file
-		_, err := client.ObjectSize(ctx, key)
-		assert.Error(t, err)
-
-		// Should be an S3 operation error
-		var s3Err ErrS3Operation
-		assert.ErrorAs(t, err, &s3Err)
-		assert.Equal(t, "head", s3Err.Operation)
-	})
-}
-
-func TestS3ClientKeyPrefixing(t *testing.T) {
-	// Start mock S3 server
-	mockServer := s3mock.New("test-bucket", "us-east-1")
-	defer mockServer.Close()
-
-	t.Run("WithPrefix", func(t *testing.T) {
-		// Create config with prefix
-		config := CreateConfigForMock(mockServer, "test-bucket", "my/prefix")
-		client, err := NewMockClient(context.Background(), mockServer, config)
-		require.NoError(t, err)
-
-		ctx := context.Background()
-		key := "test-file.txt"
-		data := []byte("test data")
-
-		// Upload data
-		err = client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Verify it's stored with prefix
-		storedData, exists := mockServer.ObjectContent("my/prefix/" + key)
-		assert.True(t, exists)
-		assert.Equal(t, data, storedData)
-
-		// Download should work without specifying prefix
-		downloaded, err := client.Download(ctx, key)
-		assert.NoError(t, err)
-		assert.Equal(t, data, downloaded)
-	})
-
-	t.Run("WithoutPrefix", func(t *testing.T) {
-		// Create config without prefix
-		config := CreateConfigForMock(mockServer, "test-bucket", "")
-		client, err := NewMockClient(context.Background(), mockServer, config)
-		require.NoError(t, err)
-
-		ctx := context.Background()
-		key := "no-prefix-file.txt"
-		data := []byte("no prefix data")
-
-		// Upload data
-		err = client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Verify it's stored without prefix
-		storedData, exists := mockServer.ObjectContent(key)
-		assert.True(t, exists)
-		assert.Equal(t, data, storedData)
-	})
-}
-
-func TestMockServerDirectly(t *testing.T) {
-	mockServer := s3mock.New("test-bucket", "us-east-1")
-	defer mockServer.Close()
-
-	t.Run("ListObjects", func(t *testing.T) {
-		// Initially empty
-		objects := mockServer.ListObjects("")
-		assert.Empty(t, objects)
-
-		// Create config and client
-		config := CreateConfigForMock(mockServer, "test-bucket", "test")
-		client, err := NewMockClient(context.Background(), mockServer, config)
-		require.NoError(t, err)
-
-		// Upload some files
-		ctx := context.Background()
-		files := map[string][]byte{
-			"file1.txt": []byte("content1"),
-			"file2.txt": []byte("content2"),
-			"file3.txt": []byte("content3"),
-		}
-
-		for key, data := range files {
-			err := client.Append(ctx, key, data)
-			assert.NoError(t, err)
-		}
-
-		// List objects
-		objects = mockServer.ListObjects("")
-		assert.Len(t, objects, 3)
-
-		// Should be sorted
-		expectedKeys := []string{
-			"test/file1.txt",
-			"test/file2.txt",
-			"test/file3.txt",
-		}
-		assert.Equal(t, expectedKeys, objects)
-	})
-
-	t.Run("GetObjectDirectly", func(t *testing.T) {
-		// Upload via client
-		config := CreateConfigForMock(mockServer, "test-bucket", "direct")
-		client, err := NewMockClient(context.Background(), mockServer, config)
-		require.NoError(t, err)
-
-		ctx := context.Background()
-		key := "direct-test.txt"
-		data := []byte("direct access test")
-
-		err = client.Append(ctx, key, data)
-		assert.NoError(t, err)
-
-		// Access directly via mock server
-		storedData, exists := mockServer.ObjectContent("direct/" + key)
-		assert.True(t, exists)
-		assert.Equal(t, data, storedData)
-
-		// Try non-existent key
-		_, exists = mockServer.ObjectContent("non-existent-key")
-		assert.False(t, exists)
-	})
+	// Size
+	size, err := client.ObjectSize(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), size)
 }
 
 func TestIsNoSuchKey(t *testing.T) {
-	t.Run("with fs.ErrNotExist", func(t *testing.T) {
-		assert.True(t, IsNoSuchKey(fs.ErrNotExist))
-	})
-
-	t.Run("with wrapped fs.ErrNotExist", func(t *testing.T) {
-		err := fmt.Errorf("wrapped: %w", fs.ErrNotExist)
-		assert.True(t, IsNoSuchKey(err))
-	})
-
-	t.Run("with 'NoSuchKey' substring", func(t *testing.T) {
-		assert.True(t, IsNoSuchKey(errors.New("some error with NoSuchKey in it")))
-	})
-
-	t.Run("with '404' substring", func(t *testing.T) {
-		assert.True(t, IsNoSuchKey(errors.New("http status 404")))
-	})
-
-	t.Run("with unrelated error", func(t *testing.T) {
-		assert.False(t, IsNoSuchKey(errors.New("some other error")))
-	})
-
-	t.Run("with nil error", func(t *testing.T) {
-		assert.False(t, IsNoSuchKey(nil))
-	})
+	assert.True(t, IsNoSuchKey(fs.ErrNotExist))
+	assert.False(t, IsNoSuchKey(nil))
 }

--- a/tales_keys.go
+++ b/tales_keys.go
@@ -15,3 +15,13 @@ func buildDailyKeys(date string) (threadsLog, threadsIdx, actorsLog, actorsIdx s
 func buildChunkKey(date string, chunk uint64) string {
 	return fmt.Sprintf("%s/%d.log", date, chunk)
 }
+
+// buildBitmapKey builds S3 key for bitmap data of a specific chunk.
+func buildBitmapKey(date string, chunk uint64) string {
+	return fmt.Sprintf("%s/%d.rbm", date, chunk)
+}
+
+// buildIndexKey builds S3 key for index data of a specific chunk.
+func buildIndexKey(date string, chunk uint64) string {
+	return fmt.Sprintf("%s/%d.idx", date, chunk)
+}

--- a/tales_test.go
+++ b/tales_test.go
@@ -98,6 +98,11 @@ func TestBuildDailyKeys(t *testing.T) {
 	assert.Equal(t, "2023-01-02/threads.idx", tidx)
 	assert.Equal(t, "2023-01-02/actors.log", alog)
 	assert.Equal(t, "2023-01-02/actors.idx", aidx)
+
+	chunk := uint64(5)
+	assert.Equal(t, "2023-01-02/5.log", buildChunkKey("2023-01-02", chunk))
+	assert.Equal(t, "2023-01-02/5.rbm", buildBitmapKey("2023-01-02", chunk))
+	assert.Equal(t, "2023-01-02/5.idx", buildIndexKey("2023-01-02", chunk))
 }
 
 func newService() (*Service, error) {


### PR DESCRIPTION
## Summary
- drop Append from S3 client
- store bitmaps and indexes as separate files per chunk
- simplify metadata and related tests
- update query logic for new bitmap/index layout

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d6f2ba2d483228c29a23b82439af1