### PR TITLE
Add metadata cache

### DIFF
--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+)
+
+// entry represents a cache entry stored in the heap.
+type entry[K comparable, V any] struct {
+	key   K
+	value V
+	ts    int64 // last access timestamp
+	idx   int   // index in heap
+}
+
+// lruHeap is a min-heap ordered by last access timestamp.
+type lruHeap[K comparable, V any] []*entry[K, V]
+
+func (h lruHeap[K, V]) Len() int           { return len(h) }
+func (h lruHeap[K, V]) Less(i, j int) bool { return h[i].ts < h[j].ts }
+func (h lruHeap[K, V]) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].idx = i; h[j].idx = j }
+func (h *lruHeap[K, V]) Push(x any)        { e := x.(*entry[K, V]); e.idx = len(*h); *h = append(*h, e) }
+func (h *lruHeap[K, V]) Pop() any {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	old[n-1] = nil
+	e.idx = -1
+	*h = old[:n-1]
+	return e
+}
+
+// LRU implements a generic LRU cache backed by a min-heap.
+type LRU[K comparable, V any] struct {
+	cap   int
+	mu    sync.Mutex
+	heap  lruHeap[K, V]
+	items map[K]*entry[K, V]
+}
+
+// NewLRU creates a new LRU cache with the given capacity.
+func NewLRU[K comparable, V any](capacity int) *LRU[K, V] {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &LRU[K, V]{
+		cap:   capacity,
+		items: make(map[K]*entry[K, V], capacity),
+	}
+}
+
+// Get retrieves a value from the cache and updates its timestamp.
+func (c *LRU[K, V]) Get(key K) (V, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.items[key]; ok {
+		e.ts = time.Now().UnixNano()
+		heap.Fix(&c.heap, e.idx)
+		return e.value, true
+	}
+	var zero V
+	return zero, false
+}
+
+// Add inserts a value into the cache, evicting the least recently used item if necessary.
+func (c *LRU[K, V]) Add(key K, value V) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now().UnixNano()
+	if e, ok := c.items[key]; ok {
+		e.value = value
+		e.ts = now
+		heap.Fix(&c.heap, e.idx)
+		return
+	}
+	e := &entry[K, V]{key: key, value: value, ts: now}
+	heap.Push(&c.heap, e)
+	c.items[key] = e
+	if len(c.heap) > c.cap {
+		oldest := heap.Pop(&c.heap).(*entry[K, V])
+		delete(c.items, oldest.key)
+	}
+}

--- a/internal/cache/lru_test.go
+++ b/internal/cache/lru_test.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLRUEviction(t *testing.T) {
+	l := NewLRU[string, int](2)
+
+	l.Add("a", 1)
+	time.Sleep(time.Microsecond)
+	l.Add("b", 2)
+	time.Sleep(time.Microsecond)
+	l.Get("a") // mark a as recently used
+	time.Sleep(time.Microsecond)
+	l.Add("c", 3) // should evict "b"
+
+	_, okA := l.Get("a")
+	_, okB := l.Get("b")
+	_, okC := l.Get("c")
+
+	assert.True(t, okA, "entry a should remain")
+	assert.False(t, okB, "entry b should be evicted")
+	assert.True(t, okC, "entry c should remain")
+}
+
+func TestLRUCapacityOne(t *testing.T) {
+	l := NewLRU[string, int](1)
+	l.Add("x", 10)
+	l.Add("y", 20)
+	_, okX := l.Get("x")
+	_, okY := l.Get("y")
+	assert.False(t, okX)
+	assert.True(t, okY)
+}

--- a/tales.go
+++ b/tales.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kelindar/tales/internal/buffer"
+	"github.com/kelindar/tales/internal/cache"
 	"github.com/kelindar/tales/internal/codec"
 	"github.com/kelindar/tales/internal/s3"
 	"github.com/kelindar/tales/internal/seq"
@@ -43,6 +44,7 @@ type Service struct {
 	config   config
 	s3Client s3.Client
 	codec    *codec.Codec
+	metaLRU  *cache.LRU[string, *codec.Metadata]
 	commands chan command
 	wg       sync.WaitGroup
 	cancel   context.CancelFunc
@@ -86,6 +88,7 @@ func New(bucket, region string, opts ...Option) (*Service, error) {
 		config:   cfg,
 		s3Client: s3Client,
 		codec:    codecInstance,
+		metaLRU:  cache.NewLRU[string, *codec.Metadata](cfg.MetadataCacheSize),
 		commands: make(chan command, cfg.BufferSize),
 		cancel:   cancel,
 	}


### PR DESCRIPTION
## Summary
- add a simple generic LRU cache implementation
- expose `WithMetadataCache` option and track cache size in `config`
- store an LRU in `Service` and use it when downloading `metadata.json`
- default cache size to 7 days of 5 minute flushes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f46a422648322806abb02595fd7b8