### PR TITLE
Move index data to metadata

### DIFF
--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -40,48 +40,44 @@ func TestLogEntry(t *testing.T) {
 
 func TestIndexEntry(t *testing.T) {
 	t.Run("CreateAndAccess", func(t *testing.T) {
-		entry := NewIndexEntry(1234567890, 42, 9876543210, 1024, 2048)
+		entry := NewIndexEntry(1234567890, 9876543210, 1024, 2048)
 
-		assert.Equal(t, uint32(1234567890), entry.Time())
-		assert.Equal(t, uint32(42), entry.Actor())
-		assert.Equal(t, uint64(9876543210), entry.Offset())
-		assert.Equal(t, uint32(1024), entry.CompressedSize())
-		assert.Equal(t, uint32(2048), entry.UncompressedSize())
+		assert.Equal(t, uint32(1234567890), entry.Time)
+		assert.Equal(t, uint64(9876543210), entry.Offset)
+		assert.Equal(t, uint32(1024), entry.Size)
+		assert.Equal(t, uint32(2048), entry.UncompressedSize)
 	})
 
 	t.Run("ZeroValues", func(t *testing.T) {
-		entry := NewIndexEntry(0, 0, 0, 0, 0)
+		entry := NewIndexEntry(0, 0, 0, 0)
 
-		assert.Equal(t, uint32(0), entry.Time())
-		assert.Equal(t, uint32(0), entry.Actor())
-		assert.Equal(t, uint64(0), entry.Offset())
-		assert.Equal(t, uint32(0), entry.CompressedSize())
-		assert.Equal(t, uint32(0), entry.UncompressedSize())
+		assert.Equal(t, uint32(0), entry.Time)
+		assert.Equal(t, uint64(0), entry.Offset)
+		assert.Equal(t, uint32(0), entry.Size)
+		assert.Equal(t, uint32(0), entry.UncompressedSize)
 	})
 }
 
 func TestChunkEntry(t *testing.T) {
 	t.Run("CreateAndAccess", func(t *testing.T) {
-		entry := NewChunkEntry(1234567890123, 1024, 2048, 4096)
+		entry := NewChunkEntry(1234567890123, 2048, 4096, nil)
 
-		assert.Equal(t, uint64(1234567890123), entry.Offset())
-		assert.Equal(t, uint32(1024), entry.IndexSize())
-		assert.Equal(t, uint32(2048), entry.BitmapSize())
-		assert.Equal(t, uint32(4096), entry.LogSize())
+		assert.Equal(t, uint64(1234567890123), entry.Offset)
+		assert.Equal(t, uint32(2048), entry.BitmapSize)
+		assert.Equal(t, uint32(4096), entry.LogSize)
 
 		// Test calculated offsets
-		assert.Equal(t, uint32(1024), entry.BitmapOffset())
-		assert.Equal(t, uint32(3072), entry.LogOffset()) // 1024 + 2048
-		assert.Equal(t, uint32(7168), entry.TotalSize()) // 1024 + 2048 + 4096
+		assert.Equal(t, uint32(0), entry.BitmapOffset())
+		assert.Equal(t, uint32(2048), entry.LogOffset())
+		assert.Equal(t, uint32(6144), entry.TotalSize())
 	})
 
 	t.Run("MaxValues", func(t *testing.T) {
-		entry := NewChunkEntry(^uint64(0), ^uint32(0), ^uint32(0), ^uint32(0))
+		entry := NewChunkEntry(^uint64(0), ^uint32(0), ^uint32(0), nil)
 
-		assert.Equal(t, ^uint64(0), entry.Offset())
-		assert.Equal(t, ^uint32(0), entry.IndexSize())
-		assert.Equal(t, ^uint32(0), entry.BitmapSize())
-		assert.Equal(t, ^uint32(0), entry.LogSize())
+		assert.Equal(t, ^uint64(0), entry.Offset)
+		assert.Equal(t, ^uint32(0), entry.BitmapSize)
+		assert.Equal(t, ^uint32(0), entry.LogSize)
 	})
 }
 
@@ -93,16 +89,6 @@ func TestEdgeCases(t *testing.T) {
 		assert.Equal(t, uint32(0), shortEntry.ID())
 		assert.Equal(t, "", shortEntry.Text())
 		assert.Nil(t, shortEntry.Actors())
-	})
-
-	t.Run("ShortIndexEntry", func(t *testing.T) {
-		shortEntry := IndexEntry([]byte{1, 2, 3})
-
-		assert.Equal(t, uint32(0), shortEntry.Time())
-		assert.Equal(t, uint32(0), shortEntry.Actor())
-		assert.Equal(t, uint64(0), shortEntry.Offset())
-		assert.Equal(t, uint32(0), shortEntry.CompressedSize())
-		assert.Equal(t, uint32(0), shortEntry.UncompressedSize())
 	})
 
 }
@@ -162,11 +148,4 @@ func TestCompression(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, largeData, decompressed)
 	})
-}
-
-func TestConstants(t *testing.T) {
-	t.Run("Sizes", func(t *testing.T) {
-		assert.Equal(t, 24, IndexEntrySize)
-	})
-
 }

--- a/internal/codec/meta.go
+++ b/internal/codec/meta.go
@@ -34,8 +34,8 @@ func DecodeMetadata(data []byte) (*Metadata, error) {
 }
 
 // Append adds a new chunk with section sizes.
-func (m *Metadata) Append(offset uint64, indexSize, bitmapSize, logSize uint32) *Metadata {
-	newChunk := NewChunkEntry(offset, indexSize, bitmapSize, logSize)
+func (m *Metadata) Append(offset uint64, bitmapSize, logSize uint32, actors map[uint32]IndexEntry) *Metadata {
+	newChunk := NewChunkEntry(offset, bitmapSize, logSize, actors)
 	m.Chunks = append(m.Chunks, newChunk)
 	m.Length = uint32(len(m.Chunks))
 	return m

--- a/internal/codec/meta_test.go
+++ b/internal/codec/meta_test.go
@@ -22,19 +22,18 @@ func TestMetadata(t *testing.T) {
 		meta := NewMetadata(time.Now())
 
 		// Add first chunk
-		meta.Append(0, 100, 200, 300)
+		meta.Append(0, 200, 300, nil)
 		assert.Equal(t, uint32(1), meta.Length)
 		assert.Len(t, meta.Chunks, 1)
 
 		// Verify chunk data
 		chunk := meta.Chunks[0]
-		assert.Equal(t, uint64(0), chunk.Offset())
-		assert.Equal(t, uint32(100), chunk.IndexSize())
-		assert.Equal(t, uint32(200), chunk.BitmapSize())
-		assert.Equal(t, uint32(300), chunk.LogSize())
+		assert.Equal(t, uint64(0), chunk.Offset)
+		assert.Equal(t, uint32(200), chunk.BitmapSize)
+		assert.Equal(t, uint32(300), chunk.LogSize)
 
 		// Add second chunk
-		meta.Append(1, 150, 250, 350)
+		meta.Append(1, 250, 350, nil)
 		assert.Equal(t, uint32(2), meta.Length)
 		assert.Len(t, meta.Chunks, 2)
 	})
@@ -43,8 +42,8 @@ func TestMetadata(t *testing.T) {
 		// Create metadata with some data
 		dayStart := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
 		original := NewMetadata(dayStart)
-		original.Append(0, 100, 200, 300)
-		original.Append(1, 150, 250, 350)
+		original.Append(0, 200, 300, nil)
+		original.Append(1, 250, 350, nil)
 
 		// Encode to JSON
 		encoded, err := EncodeMetadata(original)
@@ -67,10 +66,9 @@ func TestMetadata(t *testing.T) {
 		// Verify chunks
 		for i, originalChunk := range original.Chunks {
 			decodedChunk := decoded.Chunks[i]
-			assert.Equal(t, originalChunk.Offset(), decodedChunk.Offset())
-			assert.Equal(t, originalChunk.IndexSize(), decodedChunk.IndexSize())
-			assert.Equal(t, originalChunk.BitmapSize(), decodedChunk.BitmapSize())
-			assert.Equal(t, originalChunk.LogSize(), decodedChunk.LogSize())
+			assert.Equal(t, originalChunk.Offset, decodedChunk.Offset)
+			assert.Equal(t, originalChunk.BitmapSize, decodedChunk.BitmapSize)
+			assert.Equal(t, originalChunk.LogSize, decodedChunk.LogSize)
 		}
 	})
 


### PR DESCRIPTION
This pull request refactors the `codec` package to simplify the handling of metadata and chunk entries by replacing raw byte slices with structured types. It removes redundant methods, simplifies logic for index and chunk management, and updates related tests and service methods accordingly.

### Refactoring of Metadata and Chunk Management:

* [`internal/codec/codec.go`](diffhunk://#diff-f51af3be7f4e661f1a02cc419cbb0e4293f773bf6edcc89ef870d0807805ebf7L10-R27): Replaced raw byte slices for `IndexEntry` and `ChunkEntry` with structured types, simplifying their creation and access. Removed redundant methods for extracting fields from raw byte slices. [[1]](diffhunk://#diff-f51af3be7f4e661f1a02cc419cbb0e4293f773bf6edcc89ef870d0807805ebf7L10-R27) [[2]](diffhunk://#diff-f51af3be7f4e661f1a02cc419cbb0e4293f773bf6edcc89ef870d0807805ebf7L130-R154)

### Updates to Service Logic:

* [`tales_flush.go`](diffhunk://#diff-cb1d475f0b3d29b7cc09db64ba98e75cee2d4c0fd3024b517daf28ea4ff083ebL37-R63): Refactored `flushBuffer` to build actor metadata directly using the new `IndexEntry` structure, removing intermediate allocations for index entries. Updated logic for metadata appending. [[1]](diffhunk://#diff-cb1d475f0b3d29b7cc09db64ba98e75cee2d4c0fd3024b517daf28ea4ff083ebL37-R63) [[2]](diffhunk://#diff-cb1d475f0b3d29b7cc09db64ba98e75cee2d4c0fd3024b517daf28ea4ff083ebL107-R103)
* [`tales_query.go`](diffhunk://#diff-d4e7fc3f06306c39e0ca7eb2b323f0d0882f1d73f62fcc7255b0c73eecb18bf0L62-R92): Simplified querying logic by directly accessing actor metadata from `ChunkEntry` instead of loading and filtering index entries. Removed redundant methods for filtering and loading index data. [[1]](diffhunk://#diff-d4e7fc3f06306c39e0ca7eb2b323f0d0882f1d73f62fcc7255b0c73eecb18bf0L62-R92) [[2]](diffhunk://#diff-d4e7fc3f06306c39e0ca7eb2b323f0d0882f1d73f62fcc7255b0c73eecb18bf0L108-R111) [[3]](diffhunk://#diff-d4e7fc3f06306c39e0ca7eb2b323f0d0882f1d73f62fcc7255b0c73eecb18bf0L186-R159)

### Test Updates:

* [`internal/codec/codec_test.go`](diffhunk://#diff-b50373222fcf93b336847eb581958a98048ff748f5136e2646dc7ff50228cc08L43-R80): Updated tests for `IndexEntry` and `ChunkEntry` to reflect the new structured types and removed tests for deprecated methods. [[1]](diffhunk://#diff-b50373222fcf93b336847eb581958a98048ff748f5136e2646dc7ff50228cc08L43-R80) [[2]](diffhunk://#diff-b50373222fcf93b336847eb581958a98048ff748f5136e2646dc7ff50228cc08L98-L107) [[3]](diffhunk://#diff-b50373222fcf93b336847eb581958a98048ff748f5136e2646dc7ff50228cc08L166-L172)
* [`internal/codec/meta_test.go`](diffhunk://#diff-76d21c4fcf5caa8c78eaf6fc1f629971eb762e9f893a6fd329b9e6192195d41eL25-R36): Modified metadata tests to align with the new `Append` method and removed references to index size. [[1]](diffhunk://#diff-76d21c4fcf5caa8c78eaf6fc1f629971eb762e9f893a6fd329b9e6192195d41eL25-R36) [[2]](diffhunk://#diff-76d21c4fcf5caa8c78eaf6fc1f629971eb762e9f893a6fd329b9e6192195d41eL46-R46) [[3]](diffhunk://#diff-76d21c4fcf5caa8c78eaf6fc1f629971eb762e9f893a6fd329b9e6192195d41eL70-R71)