### PR TITLE
refactor: adjust time range calculations and add multi-day test

### DIFF
--- a/tales_query.go
+++ b/tales_query.go
@@ -51,8 +51,8 @@ func (l *Service) queryDay(ctx context.Context, actors []uint32, day time.Time, 
 	}
 
 	// Pre-compute time range in minutes once per day
-	t0 := uint32(from.Sub(day).Minutes())
-	t1 := uint32(to.Sub(day).Minutes())
+	t0 := uint32(max(0, int(from.Sub(day).Minutes())))
+	t1 := uint32(min(1440, int(to.Sub(day).Minutes()))) // 1440 minutes = 24 hours
 
 	// Pre-compute time range in seconds for chunk filtering
 	fromSec := uint32(from.Unix())


### PR DESCRIPTION
This pull request introduces enhancements to the `queryDay` function in `tales_query.go` to improve time range calculations and adds a comprehensive integration test for multi-day queries in `tales_test.go`. These changes ensure more robust handling of edge cases in time range computations and validate query behavior across multiple days.

### Improvements to time range calculations:
* [`tales_query.go`](diffhunk://#diff-d4e7fc3f06306c39e0ca7eb2b323f0d0882f1d73f62fcc7255b0c73eecb18bf0L54-R55): Updated the `queryDay` function to clamp time range calculations within valid bounds using `max` and `min` functions. This ensures the range stays between 0 and 1440 minutes (24 hours), preventing out-of-range values.

### Addition of multi-day query testing:
* `tales_test.go`: Added `TestMultiDayQuery` to validate the behavior of queries spanning multiple days. The test checks:
  - Querying for a single actor across multiple days.
  - Querying for multiple actors across multiple days.
  - Ensuring no results are returned for a future time range where no data exists.…y query tests