### PR TITLE
Add directional event scanning and cursor pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
   <br>
   <img src="https://img.shields.io/github/go-mod/go-version/kelindar/tales" alt="Go Version">
   <a href="https://pkg.go.dev/github.com/kelindar/tales"><img src="https://pkg.go.dev/badge/github.com/kelindar/tales" alt="PkgGoDev"></a>
-  <a href="https://goreportcard.com/report/github.com/kelindar/tales"><img src="https://goreportcard.com/badge/github.com/kelindar/tales" alt="Go Report Card"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
 </p>
 
@@ -64,7 +63,7 @@ func main() {
 
 	from := time.Now().Add(-time.Hour)
 	to := time.Now()
-	for event, err := range logger.Query(ctx, from, to, 12345) {
+	for event, err := range logger.Scan(ctx, from, to, 12345) {
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -79,7 +78,28 @@ func main() {
 
 `Log` returns after the event has been accepted into memory. Call `Sync` when it must be committed to S3. A failed `Close` leaves the service open so `Sync` or `Close` can be retried.
 
-Actor arguments to `Query` are combined with AND. Both time bounds are inclusive, and results are returned in a stable order. Event views are read-only and may refer to downloaded data; call `Clone` before retaining or modifying one independently.
+Actor arguments to `Scan` and `Page` are combined with AND. Both time bounds are inclusive. Results ascend when the first bound is earlier and descend when it is later. Event views are read-only and may refer to downloaded data; call `Clone` before retaining or modifying one independently.
+
+Use `Page` for bounded pagination:
+
+```go
+cursor := tales.Zero
+for {
+	events, next, err := logger.Page(ctx, to, from, cursor, 50, 12345)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, event := range events { // Newest first because to > from.
+		log.Println(event.Text())
+	}
+	if next == tales.Zero {
+		break
+	}
+	cursor = next
+}
+```
+
+`Cursor` is an opaque URL-safe string. Store it directly in a URL with `cursor.String()` and restore it with `tales.Cursor(value)`. `Page` validates malformed cursors. Reuse a cursor only with the same time bounds and actors.
 
 Each service owns one writer ID. Tales creates one automatically, or `WithWriterID("game-server-1")` can derive a stable ID from a deployment name. Only one live process may use a given writer ID.
 

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -24,6 +24,9 @@ func main() {
 	appendLogger := newLogger()
 	defer appendLogger.Close()
 
+	syncLogger := newLogger()
+	defer syncLogger.Close()
+
 	queryLogger := newLogger()
 	defer queryLogger.Close()
 	for range entries {
@@ -51,6 +54,11 @@ func main() {
 	bench.Run(func(b *bench.B) {
 		b.Run("append", func(int) {
 			must(appendLogger.Log("hello world", 1))
+		})
+
+		b.Run("sync", func(int) {
+			must(syncLogger.Log("hello world", 1))
+			must(syncLogger.Sync(ctx))
 		})
 
 		b.Run("scan-100k", func(int) {

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -20,6 +20,7 @@ const (
 )
 
 func main() {
+	ctx := context.Background()
 	appendLogger := newLogger()
 	defer appendLogger.Close()
 
@@ -28,15 +29,15 @@ func main() {
 	for range entries {
 		must(queryLogger.Log("hello world", 1))
 	}
-	must(queryLogger.Sync(context.Background()))
+	must(queryLogger.Sync(ctx))
 
 	from := time.Now().Add(-time.Hour)
-	for _, err := range queryLogger.Query(context.Background(), from, time.Now().Add(time.Hour), 1) {
+	for _, err := range queryLogger.Scan(ctx, from, time.Now().Add(time.Hour), 1) {
 		must(err)
 	}
 	to := time.Now().Add(time.Hour)
 	count := 0
-	for _, err := range queryLogger.Query(context.Background(), from, to, 1) {
+	for _, err := range queryLogger.Scan(ctx, from, to, 1) {
 		must(err)
 		count++
 	}
@@ -52,9 +53,28 @@ func main() {
 			must(appendLogger.Log("hello world", 1))
 		})
 
-		b.Run("query", func(int) {
-			for _, err := range queryLogger.Query(context.Background(), from, to, 1) {
+		b.Run("scan-100k", func(int) {
+			for _, err := range queryLogger.Scan(ctx, from, to, 1) {
 				must(err)
+			}
+		})
+
+		b.Run("scan-50", func(int) {
+			count := 0
+			for _, err := range queryLogger.Scan(ctx, to, from, 1) {
+				must(err)
+				count++
+				if count == 50 {
+					break
+				}
+			}
+		})
+
+		b.Run("page-50", func(int) {
+			events, next, err := queryLogger.Page(ctx, to, from, tales.Zero, 50, 1)
+			must(err)
+			if len(events) != 50 || next == tales.Zero {
+				panic("page incomplete")
 			}
 		})
 
@@ -63,7 +83,7 @@ func main() {
 			if index >= compactionDays {
 				panic("compaction benchmark exhausted seeded days")
 			}
-			must(compactLogger.Compact(context.Background(), firstCompactDay.AddDate(0, 0, -index)))
+			must(compactLogger.Compact(ctx, firstCompactDay.AddDate(0, 0, -index)))
 		})
 	})
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -98,7 +98,7 @@ func runSimulation(logger *tales.Service, duration time.Duration) {
 }
 
 func demoQueries(logger *tales.Service) {
-	log.Println("\n=== Query Demo ===")
+	log.Println("\n=== Scan Demo ===")
 
 	now := time.Now()
 	from := now.Add(-12 * time.Hour)
@@ -107,9 +107,9 @@ func demoQueries(logger *tales.Service) {
 	actor := actors[0]
 	log.Printf("\nConversations for %s:", actor.name)
 	count := 0
-	for event, err := range logger.Query(context.Background(), from, now, actor.id) {
+	for event, err := range logger.Scan(context.Background(), from, now, actor.id) {
 		if err != nil {
-			log.Printf("  Query failed: %v", err)
+			log.Printf("  Scan failed: %v", err)
 			return
 		}
 		log.Printf("  [%s] %s", event.Time().Format("15:04:05"), event.Text())

--- a/compact.go
+++ b/compact.go
@@ -115,10 +115,10 @@ func (l *Service) composeCompactPayload(ctx context.Context, day string, sources
 	}
 	key := keyOfCompactData(day)
 	etag, err := l.s3Client.Compose(ctx, key, parts)
-	if err != nil {
-		if s3.IsComposeUnsupported(err) {
-			return nil
-		}
+	switch {
+	case s3.IsComposeUnsupported(err):
+		return nil
+	case err != nil:
 		return err
 	}
 	var offset int64

--- a/compact.go
+++ b/compact.go
@@ -128,10 +128,10 @@ func (l *Service) composeCompactPayload(ctx context.Context, day string, sources
 		offset += parts[i].Size
 	}
 	object, err := l.s3Client.Stat(ctx, key)
-	if err != nil {
+	switch {
+	case err != nil:
 		return err
-	}
-	if object.ETag != etag || object.Size != offset {
+	case object.ETag != etag || object.Size != offset:
 		return fmt.Errorf("composed payload validation failed")
 	}
 	return nil
@@ -159,10 +159,10 @@ func (l *Service) uploadCompactIndex(ctx context.Context, day string, merged map
 		return codec.ObjectRange{}, nil, err
 	}
 	object, err := l.s3Client.Stat(ctx, key)
-	if err != nil {
+	switch {
+	case err != nil:
 		return codec.ObjectRange{}, nil, err
-	}
-	if object.ETag != etag || object.Size != int64(len(data)) {
+	case object.ETag != etag || object.Size != int64(len(data)):
 		return codec.ObjectRange{}, nil, fmt.Errorf("compacted index validation failed")
 	}
 	return codec.ObjectRange{Key: key, ETag: etag, Size: int64(len(data))}, ranges, nil
@@ -174,10 +174,10 @@ func (l *Service) validateDirectPayloads(ctx context.Context, sources []codec.Co
 			continue
 		}
 		object, err := l.s3Client.Stat(ctx, source.Source)
-		if err != nil {
+		switch {
+		case err != nil:
 			return err
-		}
-		if object.ETag != source.Payload.ETag || source.Payload.Offset+source.Payload.Size > object.Size {
+		case object.ETag != source.Payload.ETag || source.Payload.Offset+source.Payload.Size > object.Size:
 			return fmt.Errorf("direct payload validation failed")
 		}
 	}

--- a/cursor.go
+++ b/cursor.go
@@ -40,10 +40,10 @@ func encodeCursor(ref eventRef) (Cursor, error) {
 }
 
 func decodeCursor(cursor Cursor) (*cursorPosition, error) {
-	if cursor == Zero {
+	switch {
+	case cursor == Zero:
 		return nil, nil
-	}
-	if len(cursor) != 27 {
+	case len(cursor) != 27:
 		return nil, fmt.Errorf("invalid cursor length %d", len(cursor))
 	}
 	var data [20]byte

--- a/cursor.go
+++ b/cursor.go
@@ -1,0 +1,66 @@
+// Copyright (c) Roman Atachiants and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root
+
+package tales
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// Cursor is an opaque URL-safe position in Tales' deterministic event order.
+// Reuse it with the same time range and actors.
+type Cursor string
+
+// Zero starts paging at the first event in the requested direction.
+const Zero Cursor = ""
+
+type cursorPosition struct {
+	millis   int64
+	writer   uint64
+	position uint64
+}
+
+// String returns the unpadded URL-safe cursor string.
+func (c Cursor) String() string { return string(c) }
+
+func encodeCursor(ref eventRef) (Cursor, error) {
+	// ponytail: 32-bit writer-day positions cap paging below 2^32 events/day;
+	// restore separate sequence and ordinal fields if that ceiling matters.
+	if ref.position >= math.MaxUint32 {
+		return Zero, fmt.Errorf("writer-day position exceeds cursor capacity")
+	}
+	var data [20]byte
+	binary.BigEndian.PutUint64(data[0:8], uint64(ref.millis))
+	binary.BigEndian.PutUint64(data[8:16], ref.writer)
+	binary.BigEndian.PutUint32(data[16:20], uint32(ref.position)+1)
+	return Cursor(base64.RawURLEncoding.EncodeToString(data[:])), nil
+}
+
+func decodeCursor(cursor Cursor) (*cursorPosition, error) {
+	if cursor == Zero {
+		return nil, nil
+	}
+	if len(cursor) != 27 {
+		return nil, fmt.Errorf("invalid cursor length %d", len(cursor))
+	}
+	var data [20]byte
+	n, err := base64.RawURLEncoding.Decode(data[:], []byte(cursor))
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("decode cursor: %w", err)
+	case n != len(data):
+		return nil, fmt.Errorf("invalid cursor length %d", n)
+	}
+	position := binary.BigEndian.Uint32(data[16:20])
+	if position == 0 {
+		return nil, fmt.Errorf("invalid cursor position")
+	}
+	return &cursorPosition{
+		millis:   int64(binary.BigEndian.Uint64(data[0:8])),
+		writer:   binary.BigEndian.Uint64(data[8:16]),
+		position: uint64(position - 1),
+	}, nil
+}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -1,0 +1,41 @@
+package tales
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kelindar/tales/internal/codec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCursor(t *testing.T) {
+	entry, err := codec.NewLogEntry(1, "event", []uint32{1})
+	require.NoError(t, err)
+	ref := eventRef{
+		event:    codec.NewEvent(time.Unix(0, 0).UTC(), entry),
+		millis:   1,
+		writer:   0x0123456789abcdef,
+		position: 42,
+	}
+	cursor, err := encodeCursor(ref)
+	require.NoError(t, err)
+	require.Len(t, cursor.String(), 27)
+	require.Equal(t, cursor, Cursor(cursor.String()))
+	position, err := decodeCursor(cursor)
+	require.NoError(t, err)
+	require.Equal(t, &cursorPosition{millis: 1, writer: ref.writer, position: ref.position}, position)
+
+	require.Empty(t, Zero.String())
+	position, err = decodeCursor(Zero)
+	require.NoError(t, err)
+	require.Nil(t, position)
+
+	for _, value := range []string{"!", "AA", strings.Repeat("A", 27), strings.Repeat("A", 100)} {
+		_, err := decodeCursor(Cursor(value))
+		require.Error(t, err)
+	}
+
+	_, err = encodeCursor(eventRef{position: ^uint64(0)})
+	require.Error(t, err)
+}

--- a/flush.go
+++ b/flush.go
@@ -22,6 +22,7 @@ type writerState struct {
 type pendingBatch struct {
 	batch    *buffer.Batch
 	sequence uint64
+	base     uint64
 	chunk    *codec.ChunkEntry
 	err      error
 }
@@ -45,7 +46,7 @@ func (l *Service) flushState(ctx context.Context, state *writerState) error {
 	if err != nil {
 		return fmt.Errorf("encode pending batch: %w", err)
 	}
-	state.pending = &pendingBatch{batch: batch, sequence: manifest.NextSequence()}
+	state.pending = &pendingBatch{batch: batch, sequence: manifest.NextSequence(), base: manifestEntries(manifest)}
 	return l.persistPending(ctx, state, manifest)
 }
 
@@ -198,7 +199,7 @@ func (l *Service) snapshot(ctx context.Context, state *writerState) (querySnapsh
 		}
 	}
 	if pending := state.pending; pending != nil {
-		addLocalSnapshot(&snapshot, localChunk{day: pending.batch.Day, sequence: pending.sequence, entries: pending.batch.Entries, raw: pending.batch.Raw})
+		addLocalSnapshot(&snapshot, localChunk{day: pending.batch.Day, sequence: pending.sequence, base: pending.base, entries: pending.batch.Entries, raw: pending.batch.Raw})
 	}
 	if local, ok := activeSnapshot(state); ok {
 		addLocalSnapshot(&snapshot, local)
@@ -231,13 +232,24 @@ func activeSnapshot(state *writerState) (localChunk, bool) {
 	}
 	key := dayKey(day)
 	var sequence uint64
+	var base uint64
 	if manifest := state.manifests[key]; manifest != nil {
 		sequence = manifest.NextSequence()
+		base = manifestEntries(manifest)
 	}
 	if state.pending != nil && state.pending.batch.Day.Equal(day) {
 		sequence = state.pending.sequence + 1
+		base = state.pending.base + uint64(state.pending.batch.Entries)
 	}
-	return localChunk{day: day, sequence: sequence, entries: entries, raw: raw}, true
+	return localChunk{day: day, sequence: sequence, base: base, entries: entries, raw: raw}, true
+}
+
+func manifestEntries(manifest *codec.Manifest) uint64 {
+	var total uint64
+	for _, chunk := range manifest.Chunks {
+		total += uint64(chunk.Entries)
+	}
+	return total
 }
 
 func addLocalSnapshot(snapshot *querySnapshot, local localChunk) {

--- a/flush_test.go
+++ b/flush_test.go
@@ -28,10 +28,10 @@ func TestPendingCutoff(t *testing.T) {
 	second.s3Client = client
 	defer second.Close()
 	require.NoError(t, second.Log("pending", 1))
-	events := collectEvents(t, second.Query(context.Background(), now, now, 1))
+	events := collectEvents(t, second.Scan(context.Background(), now, now, 1))
 	require.Equal(t, []string{"committed", "pending"}, eventTexts(events))
 	require.Error(t, second.Sync(context.Background()))
-	events = collectEvents(t, second.Query(context.Background(), now, now, 1))
+	events = collectEvents(t, second.Scan(context.Background(), now, now, 1))
 	require.Equal(t, []string{"committed", "pending"}, eventTexts(events))
 	client.failManifest = false
 }
@@ -47,5 +47,5 @@ func TestSyncCancellation(t *testing.T) {
 	cancel()
 	require.ErrorIs(t, service.Sync(ctx), context.Canceled)
 	require.NoError(t, service.Sync(context.Background()))
-	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Query(context.Background(), now, now, 1))))
+	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Scan(context.Background(), now, now, 1))))
 }

--- a/internal/codec/meta.go
+++ b/internal/codec/meta.go
@@ -165,20 +165,14 @@ func validateCompactSources(sources []CompactSource) error {
 
 func validateCompactSource(sources []CompactSource, i int, base uint64) error {
 	source := sources[i]
-	if source.Base != base || !validWriterID(source.Writer) || source.Entries == 0 || source.Time[0] > source.Time[1] || source.Time[1] > MaxMillis || source.Payload.Key == "" || source.Payload.ETag == "" || source.Payload.Offset < 0 || source.Payload.Size <= 0 || source.Payload.Offset > math.MaxInt64-source.Payload.Size || source.Source == "" {
+	switch {
+	case source.Base != base || !validWriterID(source.Writer) || source.Entries == 0 || source.Time[0] > source.Time[1] || source.Time[1] > MaxMillis || source.Payload.Key == "" || source.Payload.ETag == "" || source.Payload.Offset < 0 || source.Payload.Size <= 0 || source.Payload.Offset > math.MaxInt64-source.Payload.Size || source.Source == "":
 		return fmt.Errorf("invalid compact source %d", i)
-	}
-	if i == 0 {
-		if source.Sequence != 0 {
-			return fmt.Errorf("compact sources are not ordered")
-		}
-	} else {
-		previous := sources[i-1]
-		if source.Writer < previous.Writer || source.Writer == previous.Writer && source.Sequence != previous.Sequence+1 || source.Writer > previous.Writer && source.Sequence != 0 {
-			return fmt.Errorf("compact sources are not ordered")
-		}
-	}
-	if !source.Copied && source.Payload.Key != source.Source {
+	case i == 0 && source.Sequence != 0:
+		return fmt.Errorf("compact sources are not ordered")
+	case i > 0 && (source.Writer < sources[i-1].Writer || source.Writer == sources[i-1].Writer && source.Sequence != sources[i-1].Sequence+1 || source.Writer > sources[i-1].Writer && source.Sequence != 0):
+		return fmt.Errorf("compact sources are not ordered")
+	case !source.Copied && source.Payload.Key != source.Source:
 		return fmt.Errorf("direct compact source %d has mismatched payload", i)
 	}
 	return nil

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -144,11 +144,11 @@ func (c *S3Client) DownloadRange(ctx context.Context, key, etag string, offset, 
 	if err == nil {
 		err = ctx.Err()
 	}
-	if err == nil && int64(len(data)) != size {
-		err = io.ErrUnexpectedEOF
-	}
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, ErrS3Operation{Operation: "range", Err: err}
+	case int64(len(data)) != size:
+		return nil, ErrS3Operation{Operation: "range", Err: io.ErrUnexpectedEOF}
 	}
 	return data, nil
 }

--- a/mock/service.go
+++ b/mock/service.go
@@ -1,9 +1,14 @@
 package mock
 
 import (
+	"cmp"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"iter"
+	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -13,17 +18,20 @@ import (
 
 // Service is an in-memory implementation of tales.Manager for tests.
 type Service struct {
-	mu       sync.RWMutex
-	capacity int
-	buf      []logEntry
-	next     int
-	size     int
-	closed   bool
+	mu        sync.RWMutex
+	capacity  int
+	buf       []logEntry
+	next      int
+	size      int
+	serialDay time.Time
+	serial    uint32
+	closed    bool
 }
 
 type logEntry struct {
-	day   time.Time
-	entry codec.LogEntry
+	day      time.Time
+	entry    codec.LogEntry
+	position uint32
 }
 
 // NewService creates a fixed-capacity in-memory event log.
@@ -49,7 +57,14 @@ func (s *Service) Log(text string, actors ...uint32) error {
 	if s.closed {
 		return fmt.Errorf("tales service is closed")
 	}
-	s.buf[s.next] = logEntry{day: day, entry: entry}
+	if !s.serialDay.Equal(day) {
+		s.serialDay, s.serial = day, 0
+	}
+	if s.serial == math.MaxUint32 {
+		return fmt.Errorf("writer-day position exceeds cursor capacity")
+	}
+	s.buf[s.next] = logEntry{day: day, entry: entry, position: s.serial}
+	s.serial++
 	s.next = (s.next + 1) % s.capacity
 	if s.size < s.capacity {
 		s.size++
@@ -57,42 +72,139 @@ func (s *Service) Log(text string, actors ...uint32) error {
 	return nil
 }
 
-func (s *Service) Query(ctx context.Context, from, to time.Time, actors ...uint32) iter.Seq2[tales.Event, error] {
+func (s *Service) Scan(ctx context.Context, from, to time.Time, actors ...uint32) iter.Seq2[tales.Event, error] {
 	return func(yield func(tales.Event, error) bool) {
-		if ctx == nil || from.After(to) || len(actors) == 0 {
-			yield(tales.Event{}, fmt.Errorf("invalid query arguments"))
+		refs, err := s.query(ctx, from, to, actors)
+		if err != nil {
+			yield(tales.Event{}, err)
 			return
 		}
-		s.mu.RLock()
-		if s.closed {
-			s.mu.RUnlock()
-			yield(tales.Event{}, fmt.Errorf("tales service is closed"))
-			return
-		}
-		index := s.next - s.size
-		if index < 0 {
-			index += s.capacity
-		}
-		entries := make([]logEntry, 0, s.size)
-		for range s.size {
-			entries = append(entries, s.buf[index])
-			index = (index + 1) % s.capacity
-		}
-		s.mu.RUnlock()
-		for _, entry := range entries {
-			if err := ctx.Err(); err != nil {
-				yield(tales.Event{}, err)
-				return
-			}
-			event := codec.NewEvent(entry.day, entry.entry)
-			if event.Time().Before(from) || event.Time().After(to) || !containsAll(entry.entry, actors) {
-				continue
-			}
-			if !yield(event, nil) {
+		for _, ref := range refs {
+			if !yield(ref.event, nil) {
 				return
 			}
 		}
 	}
+}
+
+func (s *Service) Page(ctx context.Context, from, to time.Time, cursor tales.Cursor, limit int, actors ...uint32) ([]tales.Event, tales.Cursor, error) {
+	if limit < 1 || limit > 1000 {
+		return nil, tales.Zero, fmt.Errorf("invalid limit")
+	}
+	refs, err := s.query(ctx, from, to, actors)
+	if err != nil {
+		return nil, tales.Zero, err
+	}
+	ascending := !from.After(to)
+	var cursorTime int64
+	var cursorPosition uint32
+	if cursor != tales.Zero {
+		if len(cursor) != 27 {
+			return nil, tales.Zero, fmt.Errorf("invalid cursor")
+		}
+		var data [20]byte
+		n, err := base64.RawURLEncoding.Decode(data[:], []byte(cursor))
+		if err != nil || n != len(data) {
+			return nil, tales.Zero, fmt.Errorf("invalid cursor")
+		}
+		cursorTime = int64(binary.BigEndian.Uint64(data[0:8]))
+		encoded := binary.BigEndian.Uint32(data[16:20])
+		if encoded == 0 {
+			return nil, tales.Zero, fmt.Errorf("invalid cursor")
+		}
+		cursorPosition = encoded - 1
+		lower, upper := from, to
+		if from.After(to) {
+			lower, upper = to, from
+		}
+		at := time.UnixMilli(cursorTime)
+		if at.Before(lower) || at.After(upper) {
+			return nil, tales.Zero, fmt.Errorf("cursor timestamp outside query range")
+		}
+	}
+	filtered := refs[:0]
+	for _, ref := range refs {
+		if cursor != tales.Zero {
+			order := cmp.Compare(ref.event.Time().UnixMilli(), cursorTime)
+			if order == 0 {
+				order = cmp.Compare(ref.position, cursorPosition)
+			}
+			if ascending && order <= 0 || !ascending && order >= 0 {
+				continue
+			}
+		}
+		filtered = append(filtered, ref)
+		if len(filtered) == limit+1 {
+			break
+		}
+	}
+	events := make([]tales.Event, min(limit, len(filtered)))
+	for i := range events {
+		events[i] = filtered[i].event
+	}
+	next := tales.Zero
+	if len(filtered) > limit {
+		last := filtered[limit-1]
+		var data [20]byte
+		binary.BigEndian.PutUint64(data[0:8], uint64(last.event.Time().UnixMilli()))
+		binary.BigEndian.PutUint32(data[16:20], last.position+1)
+		next = tales.Cursor(base64.RawURLEncoding.EncodeToString(data[:]))
+	}
+	return events, next, nil
+}
+
+type eventRef struct {
+	event    tales.Event
+	position uint32
+}
+
+func (s *Service) query(ctx context.Context, from, to time.Time, actors []uint32) ([]eventRef, error) {
+	if ctx == nil || len(actors) == 0 {
+		return nil, fmt.Errorf("invalid query arguments")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("tales service is closed")
+	}
+	index := s.next - s.size
+	if index < 0 {
+		index += s.capacity
+	}
+	entries := make([]logEntry, 0, s.size)
+	for range s.size {
+		entries = append(entries, s.buf[index])
+		index = (index + 1) % s.capacity
+	}
+	s.mu.RUnlock()
+
+	lower, upper := from, to
+	ascending := !from.After(to)
+	if !ascending {
+		lower, upper = to, from
+	}
+	refs := make([]eventRef, 0, len(entries))
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		event := codec.NewEvent(entry.day, entry.entry)
+		if event.Time().Before(lower) || event.Time().After(upper) || !containsAll(entry.entry, actors) {
+			continue
+		}
+		refs = append(refs, eventRef{event: event, position: entry.position})
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		order := refs[i].event.Time().Compare(refs[j].event.Time())
+		if order == 0 {
+			order = cmp.Compare(refs[i].position, refs[j].position)
+		}
+		return ascending && order < 0 || !ascending && order > 0
+	})
+	return refs, nil
 }
 
 func containsAll(entry codec.LogEntry, actors []uint32) bool {

--- a/mock/service.go
+++ b/mock/service.go
@@ -104,23 +104,24 @@ func (s *Service) Page(ctx context.Context, from, to time.Time, cursor tales.Cur
 		}
 		var data [20]byte
 		n, err := base64.RawURLEncoding.Decode(data[:], []byte(cursor))
-		if err != nil || n != len(data) {
+		switch {
+		case err != nil, n != len(data):
 			return nil, tales.Zero, fmt.Errorf("invalid cursor")
 		}
 		cursorTime = int64(binary.BigEndian.Uint64(data[0:8]))
 		encoded := binary.BigEndian.Uint32(data[16:20])
-		if encoded == 0 {
-			return nil, tales.Zero, fmt.Errorf("invalid cursor")
-		}
-		cursorPosition = encoded - 1
 		lower, upper := from, to
 		if from.After(to) {
 			lower, upper = to, from
 		}
 		at := time.UnixMilli(cursorTime)
-		if at.Before(lower) || at.After(upper) {
+		switch {
+		case encoded == 0:
+			return nil, tales.Zero, fmt.Errorf("invalid cursor")
+		case at.Before(lower), at.After(upper):
 			return nil, tales.Zero, fmt.Errorf("cursor timestamp outside query range")
 		}
+		cursorPosition = encoded - 1
 	}
 	filtered := refs[:0]
 	for _, ref := range refs {
@@ -221,11 +222,11 @@ func containsAll(entry codec.LogEntry, actors []uint32) bool {
 }
 
 func (s *Service) Sync(ctx context.Context) error {
-	if ctx == nil {
+	switch {
+	case ctx == nil:
 		return fmt.Errorf("nil context")
-	}
-	if err := ctx.Err(); err != nil {
-		return err
+	case ctx.Err() != nil:
+		return ctx.Err()
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/mock/service_test.go
+++ b/mock/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kelindar/tales"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,14 +35,14 @@ func testLogQuery(t *testing.T) {
 	to := now.Add(time.Minute)
 
 	var results []string
-	for event, err := range svc.Query(context.Background(), from, to, 1) {
+	for event, err := range svc.Scan(context.Background(), from, to, 1) {
 		assert.NoError(t, err)
 		results = append(results, event.Text())
 	}
 	assert.Equal(t, []string{"third"}, results)
 
 	results = results[:0]
-	for event, err := range svc.Query(context.Background(), from, to, 2) {
+	for event, err := range svc.Scan(context.Background(), from, to, 2) {
 		assert.NoError(t, err)
 		results = append(results, event.Text())
 	}
@@ -59,7 +60,7 @@ func testQueryIntersection(t *testing.T) {
 	to := now.Add(time.Minute)
 
 	var res []string
-	for event, err := range svc.Query(context.Background(), from, to, 1, 2) {
+	for event, err := range svc.Scan(context.Background(), from, to, 1, 2) {
 		assert.NoError(t, err)
 		res = append(res, event.Text())
 	}
@@ -92,23 +93,32 @@ func testQueryFilters(t *testing.T) {
 	to := now.Add(time.Minute)
 
 	var texts []string
-	for event, err := range svc.Query(context.Background(), from, to, 1) {
+	for event, err := range svc.Scan(context.Background(), from, to, 1) {
 		assert.NoError(t, err)
 		texts = append(texts, event.Text())
 	}
 	assert.Equal(t, []string{"keep"}, texts)
 
-	for range svc.Query(context.Background(), now.Add(time.Hour), now.Add(2*time.Hour), 1) {
+	for range svc.Scan(context.Background(), now.Add(time.Hour), now.Add(2*time.Hour), 1) {
 		t.Fatal("expected no results outside time range")
 	}
 
 	count := 0
 	svc.Log("second", 1)
-	for range svc.Query(context.Background(), from, to, 1) {
+	for range svc.Scan(context.Background(), from, to, 1) {
 		count++
 		break
 	}
 	assert.Equal(t, 1, count)
+
+	events, next, err := svc.Page(context.Background(), to, from, tales.Zero, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{"second"}, []string{events[0].Text()})
+	require.NotEmpty(t, next)
+	events, next, err = svc.Page(context.Background(), to, from, next, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{"keep"}, []string{events[0].Text()})
+	require.Empty(t, next)
 }
 
 func testServiceEdges(t *testing.T) {
@@ -125,21 +135,23 @@ func testServiceEdges(t *testing.T) {
 	require.NoError(t, svc.Log("ok", 1))
 	require.NoError(t, svc.Sync(context.Background()))
 
-	for _, err := range svc.Query(nil, time.Now().Add(-time.Minute), time.Now(), 1) {
+	for _, err := range svc.Scan(nil, time.Now().Add(-time.Minute), time.Now(), 1) {
 		require.Error(t, err)
 		break
 	}
-	for _, err := range svc.Query(context.Background(), time.Now(), time.Now().Add(-time.Minute), 1) {
-		require.Error(t, err)
-		break
+	count := 0
+	for _, err := range svc.Scan(context.Background(), time.Now(), time.Now().Add(-time.Minute), 1) {
+		require.NoError(t, err)
+		count++
 	}
-	for _, err := range svc.Query(context.Background(), time.Now().Add(-time.Minute), time.Now()) {
+	require.Equal(t, 1, count)
+	for _, err := range svc.Scan(context.Background(), time.Now().Add(-time.Minute), time.Now()) {
 		require.Error(t, err)
 		break
 	}
 
 	require.NoError(t, svc.Close())
-	for _, err := range svc.Query(context.Background(), time.Now().Add(-time.Minute), time.Now(), 1) {
+	for _, err := range svc.Scan(context.Background(), time.Now().Add(-time.Minute), time.Now(), 1) {
 		require.Error(t, err)
 		break
 	}

--- a/query.go
+++ b/query.go
@@ -59,31 +59,16 @@ func (e invalidBitmapError) Unwrap() error { return e.err }
 // the other, ascending when from <= to and descending otherwise. The cursor is
 // exclusive; an empty next cursor ends iteration.
 func (l *Service) Page(ctx context.Context, from, to time.Time, cursor Cursor, limit int, actors ...uint32) ([]Event, Cursor, error) {
-	switch {
-	case ctx == nil:
-		return nil, Zero, fmt.Errorf("nil context")
-	case ctx.Err() != nil:
-		return nil, Zero, ctx.Err()
-	case len(actors) == 0:
-		return nil, Zero, fmt.Errorf("no actors specified")
-	case limit < 1:
-		return nil, Zero, fmt.Errorf("limit must be at least 1")
-	case limit > 1000:
-		return nil, Zero, fmt.Errorf("limit exceeds maximum of 1000")
+	if err := validatePage(ctx, limit, actors); err != nil {
+		return nil, Zero, err
 	}
-
 	position, err := decodeCursor(cursor)
 	if err != nil {
 		return nil, Zero, err
 	}
-	from, to = from.UTC(), to.UTC()
-	ascending := !from.After(to)
-	lower, upper := minTime(from, to), maxTime(from, to)
-	if position != nil {
-		at := time.UnixMilli(position.millis)
-		if at.Before(lower) || at.After(upper) {
-			return nil, Zero, fmt.Errorf("cursor timestamp outside query range")
-		}
+	window, err := newPageWindow(from.UTC(), to.UTC(), position)
+	if err != nil {
+		return nil, Zero, err
 	}
 	if err := l.begin(); err != nil {
 		return nil, Zero, err
@@ -94,59 +79,115 @@ func (l *Service) Page(ctx context.Context, from, to time.Time, cursor Cursor, l
 	if err != nil {
 		return nil, Zero, err
 	}
-	actors = uniqueActors(actors)
+	events, last, more, err := l.collectPage(ctx, snapshot, window, position, uniqueActors(actors), limit)
+	if err != nil {
+		return nil, Zero, err
+	}
+	if !more {
+		return events, Zero, nil
+	}
+	next, err := encodeCursor(last)
+	if err != nil {
+		return nil, Zero, err
+	}
+	return events, next, nil
+}
+
+func validatePage(ctx context.Context, limit int, actors []uint32) error {
+	switch {
+	case ctx == nil:
+		return fmt.Errorf("nil context")
+	case ctx.Err() != nil:
+		return ctx.Err()
+	case len(actors) == 0:
+		return fmt.Errorf("no actors specified")
+	case limit < 1:
+		return fmt.Errorf("limit must be at least 1")
+	case limit > 1000:
+		return fmt.Errorf("limit exceeds maximum of 1000")
+	}
+	return nil
+}
+
+type pageWindow struct {
+	ascending         bool
+	lower, upper      time.Time
+	firstDay, lastDay time.Time
+	step              int
+}
+
+func newPageWindow(from, to time.Time, position *cursorPosition) (pageWindow, error) {
+	ascending := !from.After(to)
+	lower, upper := minTime(from, to), maxTime(from, to)
 	if position != nil {
-		if ascending {
-			lower = time.UnixMilli(position.millis)
-		} else {
-			upper = time.UnixMilli(position.millis)
+		at := time.UnixMilli(position.millis)
+		if at.Before(lower) || at.After(upper) {
+			return pageWindow{}, fmt.Errorf("cursor timestamp outside query range")
+		}
+		switch {
+		case ascending:
+			lower = at
+		default:
+			upper = at
 		}
 	}
 	firstDay, lastDay, step := dayOf(lower), dayOf(upper), 1
 	if !ascending {
 		firstDay, lastDay, step = lastDay, firstDay, -1
 	}
+	return pageWindow{
+		ascending: ascending,
+		lower:     lower,
+		upper:     upper,
+		firstDay:  firstDay,
+		lastDay:   lastDay,
+		step:      step,
+	}, nil
+}
+
+func (l *Service) collectPage(ctx context.Context, snapshot querySnapshot, window pageWindow, position *cursorPosition, actors []uint32, limit int) ([]Event, eventRef, bool, error) {
 	events := make([]Event, 0, limit)
 	var last eventRef
-	more := false
-	for day := firstDay; ; day = day.AddDate(0, 0, step) {
+	for day := window.firstDay; ; day = day.AddDate(0, 0, window.step) {
 		if err := ctx.Err(); err != nil {
-			return nil, Zero, err
+			return nil, eventRef{}, false, err
 		}
-		dayFrom := maxTime(lower, day)
-		dayTo := minTime(upper, day.Add(24*time.Hour-time.Millisecond))
+		dayFrom := maxTime(window.lower, day)
+		dayTo := minTime(window.upper, day.Add(24*time.Hour-time.Millisecond))
 		found, err := l.queryDay(ctx, snapshot, day, dayFrom, dayTo, actors)
 		if err != nil {
-			return nil, Zero, err
+			return nil, eventRef{}, false, err
 		}
-		sortEventRefs(found, ascending)
-		for _, ref := range found {
-			if position != nil {
-				order := compareEventCursor(ref, *position)
-				if ascending && order <= 0 || !ascending && order >= 0 {
-					continue
-				}
-			}
-			if len(events) == limit {
-				more = true
-				break
-			}
-			events = append(events, ref.event)
-			last = ref
-		}
-		if more || day.Equal(lastDay) {
-			break
-		}
-	}
+		sortEventRefs(found, window.ascending)
 
-	var next Cursor
-	if more {
-		next, err = encodeCursor(last)
-		if err != nil {
-			return nil, Zero, err
+		var full bool
+		events, last, full = takePageEvents(events, last, found, position, window.ascending, limit)
+		if full || day.Equal(window.lastDay) {
+			return events, last, full, nil
 		}
 	}
-	return events, next, nil
+}
+
+func takePageEvents(events []Event, last eventRef, found []eventRef, position *cursorPosition, ascending bool, limit int) ([]Event, eventRef, bool) {
+	for _, ref := range found {
+		if skipBeforeCursor(ref, position, ascending) {
+			continue
+		}
+		if len(events) == limit {
+			return events, last, true
+		}
+		events = append(events, ref.event)
+		last = ref
+	}
+	return events, last, false
+}
+
+func skipBeforeCursor(ref eventRef, position *cursorPosition, ascending bool) bool {
+	if position == nil {
+		return false
+	}
+	order := compareEventCursor(ref, *position)
+	return ascending && order <= 0 || !ascending && order >= 0
 }
 
 func (l *Service) scan(ctx context.Context, snapshot querySnapshot, from, to time.Time, actors []uint32, yield func(Event, error) bool) {

--- a/query.go
+++ b/query.go
@@ -5,12 +5,13 @@ package tales
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"path"
 	"slices"
-	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ type writerCutoff struct {
 type localChunk struct {
 	day      time.Time
 	sequence uint64
+	base     uint64
 	entries  uint32
 	raw      []byte
 }
@@ -43,9 +45,9 @@ type querySnapshot struct {
 
 type eventRef struct {
 	event    Event
-	writer   string
-	sequence uint64
-	ordinal  uint32
+	millis   int64
+	writer   uint64
+	position uint64
 }
 
 type invalidBitmapError struct{ err error }
@@ -53,37 +55,169 @@ type invalidBitmapError struct{ err error }
 func (e invalidBitmapError) Error() string { return e.err.Error() }
 func (e invalidBitmapError) Unwrap() error { return e.err }
 
-func (l *Service) query(ctx context.Context, snapshot querySnapshot, from, to time.Time, actors []uint32, yield func(Event, error) bool) {
+// Page returns at most limit matching events from one inclusive bound toward
+// the other, ascending when from <= to and descending otherwise. The cursor is
+// exclusive; an empty next cursor ends iteration.
+func (l *Service) Page(ctx context.Context, from, to time.Time, cursor Cursor, limit int, actors ...uint32) ([]Event, Cursor, error) {
+	switch {
+	case ctx == nil:
+		return nil, Zero, fmt.Errorf("nil context")
+	case ctx.Err() != nil:
+		return nil, Zero, ctx.Err()
+	case len(actors) == 0:
+		return nil, Zero, fmt.Errorf("no actors specified")
+	case limit < 1:
+		return nil, Zero, fmt.Errorf("limit must be at least 1")
+	case limit > 1000:
+		return nil, Zero, fmt.Errorf("limit exceeds maximum of 1000")
+	}
+
+	position, err := decodeCursor(cursor)
+	if err != nil {
+		return nil, Zero, err
+	}
+	from, to = from.UTC(), to.UTC()
+	ascending := !from.After(to)
+	lower, upper := minTime(from, to), maxTime(from, to)
+	if position != nil {
+		at := time.UnixMilli(position.millis)
+		if at.Before(lower) || at.After(upper) {
+			return nil, Zero, fmt.Errorf("cursor timestamp outside query range")
+		}
+	}
+	if err := l.begin(); err != nil {
+		return nil, Zero, err
+	}
+	defer l.active.Done()
+
+	snapshot, err := l.acquireSnapshot(ctx)
+	if err != nil {
+		return nil, Zero, err
+	}
 	actors = uniqueActors(actors)
-	for day := dayOf(from); !day.After(dayOf(to)); day = day.AddDate(0, 0, 1) {
+	if position != nil {
+		if ascending {
+			lower = time.UnixMilli(position.millis)
+		} else {
+			upper = time.UnixMilli(position.millis)
+		}
+	}
+	firstDay, lastDay, step := dayOf(lower), dayOf(upper), 1
+	if !ascending {
+		firstDay, lastDay, step = lastDay, firstDay, -1
+	}
+	events := make([]Event, 0, limit)
+	var last eventRef
+	more := false
+	for day := firstDay; ; day = day.AddDate(0, 0, step) {
+		if err := ctx.Err(); err != nil {
+			return nil, Zero, err
+		}
+		dayFrom := maxTime(lower, day)
+		dayTo := minTime(upper, day.Add(24*time.Hour-time.Millisecond))
+		found, err := l.queryDay(ctx, snapshot, day, dayFrom, dayTo, actors)
+		if err != nil {
+			return nil, Zero, err
+		}
+		sortEventRefs(found, ascending)
+		for _, ref := range found {
+			if position != nil {
+				order := compareEventCursor(ref, *position)
+				if ascending && order <= 0 || !ascending && order >= 0 {
+					continue
+				}
+			}
+			if len(events) == limit {
+				more = true
+				break
+			}
+			events = append(events, ref.event)
+			last = ref
+		}
+		if more || day.Equal(lastDay) {
+			break
+		}
+	}
+
+	var next Cursor
+	if more {
+		next, err = encodeCursor(last)
+		if err != nil {
+			return nil, Zero, err
+		}
+	}
+	return events, next, nil
+}
+
+func (l *Service) scan(ctx context.Context, snapshot querySnapshot, from, to time.Time, actors []uint32, yield func(Event, error) bool) {
+	actors = uniqueActors(actors)
+	ascending := !from.After(to)
+	lower, upper := minTime(from, to), maxTime(from, to)
+	firstDay, lastDay, step := dayOf(lower), dayOf(upper), 1
+	if !ascending {
+		firstDay, lastDay, step = lastDay, firstDay, -1
+	}
+	for day := firstDay; ; day = day.AddDate(0, 0, step) {
 		if err := ctx.Err(); err != nil {
 			yield(Event{}, err)
 			return
 		}
-		refs, err := l.queryDay(ctx, snapshot, day, from, to, actors)
+		refs, err := l.queryDay(ctx, snapshot, day, lower, upper, actors)
 		if err != nil {
 			yield(Event{}, err)
 			return
 		}
-		sort.Slice(refs, func(i, j int) bool {
-			a, b := refs[i], refs[j]
-			if order := a.event.Time().Compare(b.event.Time()); order != 0 {
-				return order < 0
-			}
-			if a.writer != b.writer {
-				return a.writer < b.writer
-			}
-			if a.sequence != b.sequence {
-				return a.sequence < b.sequence
-			}
-			return a.ordinal < b.ordinal
-		})
+		sortEventRefs(refs, ascending)
 		for _, ref := range refs {
 			if !yield(ref.event, nil) {
 				return
 			}
 		}
+		if day.Equal(lastDay) {
+			break
+		}
 	}
+}
+
+func compareEventRefs(a, b eventRef) int {
+	if a.millis != b.millis {
+		return cmp.Compare(a.millis, b.millis)
+	}
+	if a.writer != b.writer {
+		return cmp.Compare(a.writer, b.writer)
+	}
+	return cmp.Compare(a.position, b.position)
+}
+
+func compareEventCursor(ref eventRef, cursor cursorPosition) int {
+	if ref.millis != cursor.millis {
+		return cmp.Compare(ref.millis, cursor.millis)
+	}
+	if ref.writer != cursor.writer {
+		return cmp.Compare(ref.writer, cursor.writer)
+	}
+	return cmp.Compare(ref.position, cursor.position)
+}
+
+func sortEventRefs(refs []eventRef, ascending bool) {
+	slices.SortFunc(refs, compareEventRefs)
+	if !ascending {
+		slices.Reverse(refs)
+	}
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
 }
 
 func (l *Service) queryDay(ctx context.Context, snapshot querySnapshot, day, from, to time.Time, actors []uint32) ([]eventRef, error) {
@@ -110,7 +244,7 @@ func (l *Service) queryDay(ctx context.Context, snapshot querySnapshot, day, fro
 	}
 	for _, local := range snapshot.local {
 		if local.day.Equal(day) {
-			localRefs, err := collectRaw(local.raw, local.entries, day, from, to, actors, l.config.WriterID, local.sequence, nil)
+			localRefs, err := collectRaw(local.raw, local.entries, day, from, to, actors, l.config.WriterID, local.base, nil)
 			if err != nil {
 				return nil, fmt.Errorf("query local snapshot: %w", err)
 			}
@@ -128,18 +262,20 @@ func (l *Service) queryWriterDay(ctx context.Context, snapshot querySnapshot, da
 	}
 	var refs []eventRef
 	for _, manifest := range manifests {
+		var base uint64
 		for _, chunk := range manifest.Chunks {
-			chunkRefs, err := l.queryWriterChunk(ctx, snapshot, day, dayName, from, to, actors, manifest.Writer, chunk)
+			chunkRefs, err := l.queryWriterChunk(ctx, snapshot, day, dayName, from, to, actors, manifest.Writer, chunk, base)
 			if err != nil {
 				return nil, err
 			}
 			refs = append(refs, chunkRefs...)
+			base += uint64(chunk.Entries)
 		}
 	}
 	return refs, nil
 }
 
-func (l *Service) queryWriterChunk(ctx context.Context, snapshot querySnapshot, day time.Time, dayName string, from, to time.Time, actors []uint32, writer string, chunk codec.ChunkEntry) ([]eventRef, error) {
+func (l *Service) queryWriterChunk(ctx context.Context, snapshot querySnapshot, day time.Time, dayName string, from, to time.Time, actors []uint32, writer string, chunk codec.ChunkEntry, base uint64) ([]eventRef, error) {
 	sequence := uint64(chunk.Sequence)
 	if writer == l.config.WriterID {
 		if cutoff, ok := snapshot.cutoffs[dayName]; ok && (!cutoff.committed || sequence > cutoff.sequence) {
@@ -163,7 +299,7 @@ func (l *Service) queryWriterChunk(ctx context.Context, snapshot querySnapshot, 
 	if err != nil {
 		return nil, fmt.Errorf("decompress writer chunk: %w", err)
 	}
-	return collectRaw(raw, chunk.Entries, day, from, to, actors, writer, sequence, selected)
+	return collectRaw(raw, chunk.Entries, day, from, to, actors, writer, base, selected)
 }
 
 func (l *Service) queryCompactDay(ctx context.Context, day, from, to time.Time, actors []uint32, meta *codec.CompactMetadata) ([]eventRef, error) {
@@ -176,8 +312,14 @@ func (l *Service) queryCompactDay(ctx context.Context, day, from, to time.Time, 
 	}
 	var refs []eventRef
 	fromMillis, toMillis := queryMillis(day, from, to)
+	var writer string
+	var base uint64
 	for _, source := range meta.Sources {
+		if source.Writer != writer {
+			writer, base = source.Writer, 0
+		}
 		if source.Time[0] > toMillis || source.Time[1] < fromMillis || !overlapsGlobal(selected, source.Base, source.Entries) {
+			base += uint64(source.Entries)
 			continue
 		}
 		compressed, err := l.s3Client.DownloadRange(ctx, source.Payload.Key, source.Payload.ETag, source.Payload.Offset, source.Payload.Size)
@@ -195,11 +337,12 @@ func (l *Service) queryCompactDay(ctx context.Context, day, from, to time.Time, 
 			}
 			return true
 		})
-		chunkRefs, err := collectRaw(raw, source.Entries, day, from, to, actors, source.Writer, uint64(source.Sequence), local)
+		chunkRefs, err := collectRaw(raw, source.Entries, day, from, to, actors, source.Writer, base, local)
 		if err != nil {
 			return nil, err
 		}
 		refs = append(refs, chunkRefs...)
+		base += uint64(source.Entries)
 	}
 	return refs, nil
 }
@@ -231,10 +374,14 @@ func (l *Service) chunkOrdinals(ctx context.Context, key, etag string, indexes m
 	return selected, nil
 }
 
-func collectRaw(raw []byte, expected uint32, day, from, to time.Time, actors []uint32, writer string, sequence uint64, selected *roaring.Bitmap) ([]eventRef, error) {
+func collectRaw(raw []byte, expected uint32, day, from, to time.Time, actors []uint32, writer string, base uint64, selected *roaring.Bitmap) ([]eventRef, error) {
 	entries, err := codec.ValidateEntries(raw, expected)
 	if err != nil {
 		return nil, err
+	}
+	writerID, err := strconv.ParseUint(writer, 16, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid writer ID %q", writer)
 	}
 	refs := make([]eventRef, 0, len(entries))
 	for ordinal, entry := range entries {
@@ -245,10 +392,12 @@ func collectRaw(raw []byte, expected uint32, day, from, to time.Time, actors []u
 			continue
 		}
 		event := codec.NewEvent(day, entry)
-		if event.Time().Before(from) || event.Time().After(to) {
+		eventTime := event.Time()
+		if eventTime.Before(from) || eventTime.After(to) {
 			continue
 		}
-		refs = append(refs, eventRef{event: event, writer: writer, sequence: sequence, ordinal: uint32(ordinal)})
+		position := base + uint64(ordinal)
+		refs = append(refs, eventRef{event: event, millis: eventTime.UnixMilli(), writer: writerID, position: position})
 	}
 	return refs, nil
 }
@@ -279,7 +428,7 @@ func (l *Service) discoverManifests(ctx context.Context, day time.Time) ([]*code
 			writers = append(writers, path.Base(path.Dir(object.Key)))
 		}
 	}
-	sort.Strings(writers)
+	slices.Sort(writers)
 	writers = slices.Compact(writers)
 	manifests := make([]*codec.Manifest, 0, len(writers))
 	for _, writer := range writers {
@@ -344,6 +493,9 @@ func decodeBitmap(data []byte, entries uint64) (*roaring.Bitmap, error) {
 }
 
 func uniqueActors(actors []uint32) []uint32 {
+	if len(actors) < 2 {
+		return actors
+	}
 	actors = slices.Clone(actors)
 	slices.Sort(actors)
 	return slices.Compact(actors)
@@ -353,12 +505,17 @@ func containsActors(entry codec.LogEntry, actors []uint32) bool {
 	if len(actors) == 0 {
 		return false
 	}
-	have := make(map[uint32]struct{})
-	for actor := range entry.Actors() {
-		have[actor] = struct{}{}
-	}
-	for _, actor := range actors {
-		if _, ok := have[actor]; !ok {
+	// ponytail: nested scans avoid a map allocation for unsynced events;
+	// add a reusable set if large actor lists become a measured hot path.
+	for _, wanted := range actors {
+		found := false
+		for actor := range entry.Actors() {
+			if actor == wanted {
+				found = true
+				break
+			}
+		}
+		if !found {
 			return false
 		}
 	}

--- a/query.go
+++ b/query.go
@@ -124,10 +124,9 @@ func newPageWindow(from, to time.Time, position *cursorPosition) (pageWindow, er
 		if at.Before(lower) || at.After(upper) {
 			return pageWindow{}, fmt.Errorf("cursor timestamp outside query range")
 		}
-		switch {
-		case ascending:
+		if ascending {
 			lower = at
-		default:
+		} else {
 			upper = at
 		}
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -46,7 +46,7 @@ func TestCompactFallback(t *testing.T) {
 
 	reader := testService(t, server, "fallback", "reader", func(c *config) { c.now = func() time.Time { return now } })
 	defer reader.Close()
-	events := collectEvents(t, reader.Query(context.Background(), day.Add(-time.Hour), day.Add(time.Hour), 1))
+	events := collectEvents(t, reader.Scan(context.Background(), day.Add(-time.Hour), day.Add(time.Hour), 1))
 	require.Equal(t, []string{"one"}, eventTexts(events))
 }
 
@@ -63,7 +63,7 @@ func TestQueryTime(t *testing.T) {
 		second := now
 		require.NoError(t, service.Log("first", 1))
 		require.NoError(t, service.Sync(context.Background()))
-		events := collectEvents(t, service.Query(context.Background(), first, second, 1))
+		events := collectEvents(t, service.Scan(context.Background(), first, second, 1))
 		require.Equal(t, []string{"last", "first"}, eventTexts(events))
 		require.Equal(t, []time.Time{first, second}, []time.Time{events[0].Time(), events[1].Time()})
 	})
@@ -79,7 +79,7 @@ func TestQueryTime(t *testing.T) {
 		now = day.Add(9 * time.Hour)
 		require.NoError(t, service.Log("earlier", 1))
 		require.NoError(t, service.Sync(context.Background()))
-		events := collectEvents(t, service.Query(context.Background(), day, day.Add(24*time.Hour-time.Millisecond), 1))
+		events := collectEvents(t, service.Scan(context.Background(), day, day.Add(24*time.Hour-time.Millisecond), 1))
 		require.Equal(t, []string{"earlier", "later"}, eventTexts(events))
 	})
 }
@@ -96,17 +96,17 @@ func TestDiscoveryRefresh(t *testing.T) {
 	reader := testService(t, server, "refresh", "reader", func(c *config) { c.now = func() time.Time { return now } })
 	defer reader.Close()
 	from, to := now.Add(-time.Hour), now.Add(time.Hour)
-	require.Equal(t, []string{"a"}, eventTexts(collectEvents(t, reader.Query(context.Background(), from, to, 1))))
+	require.Equal(t, []string{"a"}, eventTexts(collectEvents(t, reader.Scan(context.Background(), from, to, 1))))
 
 	writerB := testService(t, server, "refresh", "writer-b", func(c *config) { c.now = func() time.Time { return now } })
 	defer writerB.Close()
 	require.NoError(t, writerB.Log("b", 1))
 	require.NoError(t, writerB.Sync(context.Background()))
-	require.Equal(t, []string{"a"}, eventTexts(collectEvents(t, reader.Query(context.Background(), from, to, 1))))
+	require.Equal(t, []string{"a"}, eventTexts(collectEvents(t, reader.Scan(context.Background(), from, to, 1))))
 
 	now = now.Add(reader.config.ChunkInterval)
 	to = now.Add(time.Hour)
-	require.ElementsMatch(t, []string{"a", "b"}, eventTexts(collectEvents(t, reader.Query(context.Background(), from, to, 1))))
+	require.ElementsMatch(t, []string{"a", "b"}, eventTexts(collectEvents(t, reader.Scan(context.Background(), from, to, 1))))
 }
 
 func TestQueryEdges(t *testing.T) {
@@ -115,9 +115,9 @@ func TestQueryEdges(t *testing.T) {
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	service := testService(t, server, "query-edges", "writer", func(c *config) { c.now = func() time.Time { return now } })
 	defer service.Close()
-	require.Empty(t, collectEvents(t, service.Query(context.Background(), now, now, 1)))
+	require.Empty(t, collectEvents(t, service.Scan(context.Background(), now, now, 1)))
 	require.NoError(t, service.Log("one", 1, 2))
-	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Query(context.Background(), now, now, 1, 1))))
+	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Scan(context.Background(), now, now, 1, 1))))
 }
 
 func TestQueryHelpers(t *testing.T) {
@@ -151,11 +151,282 @@ func TestQueryHelpers(t *testing.T) {
 	day := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
 	selected := roaring.New()
 	selected.Set(0)
-	refs, err := collectRaw(entry, 1, day, day, day.Add(time.Hour), []uint32{1}, "writer", 0, selected)
+	refs, err := collectRaw(entry, 1, day, day, day.Add(time.Hour), []uint32{1}, "0000000000000000", 0, selected)
 	require.NoError(t, err)
 	require.Len(t, refs, 1)
 
-	refs, err = collectRaw(entry, 1, day, day.Add(time.Hour), day.Add(2*time.Hour), []uint32{1}, "writer", 0, nil)
+	refs, err = collectRaw(entry, 1, day, day.Add(time.Hour), day.Add(2*time.Hour), []uint32{1}, "0000000000000000", 0, nil)
 	require.NoError(t, err)
 	require.Empty(t, refs)
+}
+
+func TestPage(t *testing.T) {
+	server := s3mock.New("events", "us-east-1")
+	defer server.Close()
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	service := testService(t, server, "pages", "writer", func(c *config) { c.now = func() time.Time { return now } })
+	defer service.Close()
+	from := now.Add(-time.Hour)
+	for _, text := range []string{"one", "two", "three", "four", "five"} {
+		now = now.Add(time.Millisecond)
+		require.NoError(t, service.Log(text, 1))
+	}
+	to := now.Add(time.Hour)
+
+	t.Run("empty", func(t *testing.T) {
+		events, next, err := service.Page(context.Background(), from.Add(-time.Hour), from.Add(-time.Minute), Zero, 2, 1)
+		require.NoError(t, err)
+		require.Empty(t, events)
+		require.Empty(t, next)
+	})
+	t.Run("fewer than limit", func(t *testing.T) {
+		events, next, err := service.Page(context.Background(), to, from, Zero, 10, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"five", "four", "three", "two", "one"}, eventTexts(events))
+		require.Empty(t, next)
+	})
+	t.Run("exactly limit", func(t *testing.T) {
+		events, next, err := service.Page(context.Background(), to, from, Zero, 5, 1)
+		require.NoError(t, err)
+		require.Len(t, events, 5)
+		require.Empty(t, next)
+	})
+	t.Run("more than limit", func(t *testing.T) {
+		events, next, err := service.Page(context.Background(), to, from, Zero, 2, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"five", "four"}, eventTexts(events))
+		require.NotEmpty(t, next)
+	})
+	t.Run("all pages once", func(t *testing.T) {
+		var got []Event
+		var cursor Cursor
+		for {
+			events, next, err := service.Page(context.Background(), to, from, cursor, 2, 1)
+			require.NoError(t, err)
+			got = append(got, events...)
+			if next == Zero {
+				break
+			}
+			cursor = next
+		}
+		require.Equal(t, []string{"five", "four", "three", "two", "one"}, eventTexts(got))
+	})
+	t.Run("ascending", func(t *testing.T) {
+		events, _, err := service.Page(context.Background(), from, to, Zero, 5, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"one", "two", "three", "four", "five"}, eventTexts(events))
+	})
+}
+
+func TestPageOrdering(t *testing.T) {
+	t.Run("days and one writer ties", func(t *testing.T) {
+		server := s3mock.New("events", "us-east-1")
+		defer server.Close()
+		now := time.Date(2026, 7, 18, 23, 59, 59, 999_000_000, time.UTC)
+		service := testService(t, server, "page-order", "writer",
+			WithBuffer(1),
+			func(c *config) { c.now = func() time.Time { return now } },
+		)
+		defer service.Close()
+		require.NoError(t, service.Log("old-day", 1))
+		now = now.Add(time.Millisecond)
+		require.NoError(t, service.Log("same-1", 1))
+		require.NoError(t, service.Log("same-2", 1))
+		from, to := now.Add(-time.Hour), now.Add(time.Hour)
+		ascending := collectEvents(t, service.Scan(context.Background(), from, to, 1))
+
+		var descending []Event
+		var cursor Cursor
+		for {
+			events, next, err := service.Page(context.Background(), to, from, cursor, 1, 1)
+			require.NoError(t, err)
+			descending = append(descending, events...)
+			if next == Zero {
+				break
+			}
+			cursor = next
+		}
+		require.Equal(t, []string{"same-2", "same-1", "old-day"}, eventTexts(descending))
+		require.Equal(t, eventTexts(descending), eventTexts(collectEvents(t, service.Scan(context.Background(), to, from, 1))))
+		for i := range ascending {
+			require.Equal(t, ascending[len(ascending)-1-i].Text(), descending[i].Text())
+		}
+	})
+
+	t.Run("multiple writer ties", func(t *testing.T) {
+		server := s3mock.New("events", "us-east-1")
+		defer server.Close()
+		now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+		for _, writer := range []string{"writer-a", "writer-b"} {
+			service := testService(t, server, "page-writers", writer, func(c *config) { c.now = func() time.Time { return now } })
+			require.NoError(t, service.Log(writer, 1))
+			require.NoError(t, service.Sync(context.Background()))
+			require.NoError(t, service.Close())
+		}
+		reader := testService(t, server, "page-writers", "reader", func(c *config) { c.now = func() time.Time { return now } })
+		defer reader.Close()
+		from, to := now.Add(-time.Hour), now.Add(time.Hour)
+		ascending := collectEvents(t, reader.Scan(context.Background(), from, to, 1))
+		first, next, err := reader.Page(context.Background(), to, from, Zero, 1, 1)
+		require.NoError(t, err)
+		require.NotEmpty(t, next)
+		second, done, err := reader.Page(context.Background(), to, from, next, 1, 1)
+		require.NoError(t, err)
+		require.Empty(t, done)
+		require.Equal(t, []string{ascending[1].Text(), ascending[0].Text()}, eventTexts(append(first, second...)))
+	})
+}
+
+func TestPageActors(t *testing.T) {
+	server := s3mock.New("events", "us-east-1")
+	defer server.Close()
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	service := testService(t, server, "page-actors", "writer", func(c *config) { c.now = func() time.Time { return now } })
+	defer service.Close()
+	for _, event := range []struct {
+		text   string
+		actors []uint32
+	}{
+		{"one", []uint32{1}},
+		{"both", []uint32{1, 2}},
+		{"other", []uint32{2}},
+	} {
+		now = now.Add(time.Millisecond)
+		require.NoError(t, service.Log(event.text, event.actors...))
+	}
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+	one, _, err := service.Page(context.Background(), to, from, Zero, 10, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{"both", "one"}, eventTexts(one))
+	both, _, err := service.Page(context.Background(), to, from, Zero, 10, 1, 2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"both"}, eventTexts(both))
+	unrelated, _, err := service.Page(context.Background(), to, from, Zero, 10, 3)
+	require.NoError(t, err)
+	require.Empty(t, unrelated)
+}
+
+func TestPageCursor(t *testing.T) {
+	t.Run("survives compaction", func(t *testing.T) {
+		server := s3mock.New("events", "us-east-1")
+		defer server.Close()
+		old := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+		writer := testService(t, server, "page-compact", "writer",
+			WithBuffer(1),
+			func(c *config) { c.now = func() time.Time { return old } },
+		)
+		for _, text := range []string{"one", "two", "three", "four"} {
+			require.NoError(t, writer.Log(text, 1))
+		}
+		require.NoError(t, writer.Sync(context.Background()))
+		require.NoError(t, writer.Close())
+
+		now := old.Add(72 * time.Hour)
+		service := testService(t, server, "page-compact", "compactor", func(c *config) { c.now = func() time.Time { return now } })
+		defer service.Close()
+		from, to := old.Add(-time.Hour), old.Add(time.Hour)
+		first, next, err := service.Page(context.Background(), to, from, Zero, 2, 1)
+		require.NoError(t, err)
+		require.NotEmpty(t, next)
+		require.NoError(t, service.Compact(context.Background(), old))
+		second, done, err := service.Page(context.Background(), to, from, next, 2, 1)
+		require.NoError(t, err)
+		require.Empty(t, done)
+		require.Equal(t, []string{"four", "three", "two", "one"}, eventTexts(append(first, second...)))
+
+		repeated, _, err := service.Page(context.Background(), to, from, next, 2, 1)
+		require.NoError(t, err)
+		require.Equal(t, eventTexts(second), eventTexts(repeated))
+		require.NotContains(t, eventTexts(second), first[len(first)-1].Text())
+	})
+
+	t.Run("includes unsynced local events", func(t *testing.T) {
+		server := s3mock.New("events", "us-east-1")
+		defer server.Close()
+		now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+		service := testService(t, server, "page-local", "writer", func(c *config) { c.now = func() time.Time { return now } })
+		defer service.Close()
+		require.NoError(t, service.Log("one", 1))
+		require.NoError(t, service.Log("two", 1))
+		first, next, err := service.Page(context.Background(), now.Add(time.Hour), now.Add(-time.Hour), Zero, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"two"}, eventTexts(first))
+		require.NoError(t, service.Log("new", 1))
+		second, done, err := service.Page(context.Background(), now.Add(time.Hour), now.Add(-time.Hour), next, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"one"}, eventTexts(second))
+		require.Empty(t, done)
+	})
+}
+
+func TestPageValidation(t *testing.T) {
+	server := s3mock.New("events", "us-east-1")
+	defer server.Close()
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	service := testService(t, server, "page-validation", "writer", func(c *config) { c.now = func() time.Time { return now } })
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+
+	_, _, err := service.Page(nil, from, to, Zero, 1, 1)
+	require.Error(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = service.Page(ctx, from, to, Zero, 1, 1)
+	require.ErrorIs(t, err, context.Canceled)
+	for name, call := range map[string]func() error{
+		"actors": func() error {
+			_, _, err := service.Page(context.Background(), from, to, Zero, 1)
+			return err
+		},
+		"zero limit": func() error {
+			_, _, err := service.Page(context.Background(), from, to, Zero, 0, 1)
+			return err
+		},
+		"negative limit": func() error {
+			_, _, err := service.Page(context.Background(), from, to, Zero, -1, 1)
+			return err
+		},
+		"large limit": func() error {
+			_, _, err := service.Page(context.Background(), from, to, Zero, 1001, 1)
+			return err
+		},
+		"cursor": func() error {
+			_, _, err := service.Page(context.Background(), from, to, Cursor("invalid"), 1, 1)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) { require.Error(t, call()) })
+	}
+
+	require.NoError(t, service.Log("one", 1))
+	require.NoError(t, service.Log("two", 1))
+	_, next, err := service.Page(context.Background(), to, from, Zero, 1, 1)
+	require.NoError(t, err)
+	_, _, err = service.Page(context.Background(), now.Add(-time.Millisecond), from.Add(-time.Hour), next, 1, 1)
+	require.Error(t, err)
+	require.NoError(t, service.Close())
+	_, _, err = service.Page(context.Background(), from, to, Zero, 1, 1)
+	require.Error(t, err)
+
+}
+
+func ExampleService_Page() {
+	var log *Service
+	ctx := context.Background()
+	start, now := time.Now().Add(-time.Hour), time.Now()
+	actors := []uint32{42}
+	var cursor Cursor
+
+	for {
+		events, next, err := log.Page(ctx, now, start, cursor, 50, actors...)
+		if err != nil {
+			return
+		}
+		for _, event := range events { // Newest first: now toward start.
+			_ = event.Bytes()
+		}
+		if next == Zero {
+			break
+		}
+		cursor = next // Reuse with the same bounds and actors.
+	}
 }

--- a/tales.go
+++ b/tales.go
@@ -26,9 +26,10 @@ type Logger interface {
 	Log(text string, actors ...uint32) error
 }
 
-// Querier reads events in deterministic order within inclusive time bounds.
+// Querier reads events in deterministic order.
 type Querier interface {
-	Query(context.Context, time.Time, time.Time, ...uint32) iter.Seq2[Event, error]
+	Page(context.Context, time.Time, time.Time, Cursor, int, ...uint32) ([]Event, Cursor, error)
+	Scan(context.Context, time.Time, time.Time, ...uint32) iter.Seq2[Event, error]
 }
 
 // Syncer makes all previously accepted events durable.
@@ -207,14 +208,15 @@ func (l *Service) Sync(ctx context.Context) error {
 	}
 }
 
-// Query yields events containing every actor within inclusive time bounds.
-func (l *Service) Query(ctx context.Context, from, to time.Time, actors ...uint32) iter.Seq2[Event, error] {
+// Scan yields events containing every actor from one inclusive bound toward
+// the other, ascending when from <= to and descending otherwise.
+func (l *Service) Scan(ctx context.Context, from, to time.Time, actors ...uint32) iter.Seq2[Event, error] {
 	return func(yield func(Event, error) bool) {
 		switch {
 		case ctx == nil:
 			yield(Event{}, fmt.Errorf("nil context"))
 			return
-		case from.After(to) || len(actors) == 0:
+		case len(actors) == 0:
 			yield(Event{}, fmt.Errorf("invalid query arguments"))
 			return
 		}
@@ -224,25 +226,27 @@ func (l *Service) Query(ctx context.Context, from, to time.Time, actors ...uint3
 		}
 		defer l.active.Done()
 
-		reply := make(chan snapshotResult, 1)
-		select {
-		case l.commands <- command{snapshot: &snapshotCmd{ctx: ctx, reply: reply}}:
-		case <-ctx.Done():
-			yield(Event{}, ctx.Err())
+		snapshot, err := l.acquireSnapshot(ctx)
+		if err != nil {
+			yield(Event{}, err)
 			return
 		}
-		var result snapshotResult
-		select {
-		case result = <-reply:
-		case <-ctx.Done():
-			yield(Event{}, ctx.Err())
-			return
-		}
-		if result.err != nil {
-			yield(Event{}, result.err)
-			return
-		}
-		l.query(ctx, result.snapshot, from.UTC(), to.UTC(), actors, yield)
+		l.scan(ctx, snapshot, from.UTC(), to.UTC(), actors, yield)
+	}
+}
+
+func (l *Service) acquireSnapshot(ctx context.Context) (querySnapshot, error) {
+	reply := make(chan snapshotResult, 1)
+	select {
+	case l.commands <- command{snapshot: &snapshotCmd{ctx: ctx, reply: reply}}:
+	case <-ctx.Done():
+		return querySnapshot{}, ctx.Err()
+	}
+	select {
+	case result := <-reply:
+		return result.snapshot, result.err
+	case <-ctx.Done():
+		return querySnapshot{}, ctx.Err()
 	}
 }
 

--- a/tales_test.go
+++ b/tales_test.go
@@ -51,7 +51,7 @@ func TestDistributedWriters(t *testing.T) {
 
 	reader := testService(t, server, "shared", "reader", func(c *config) { c.now = func() time.Time { return now } })
 	defer reader.Close()
-	events := collectEvents(t, reader.Query(context.Background(), now.Add(-time.Second), now.Add(time.Second), 1))
+	events := collectEvents(t, reader.Scan(context.Background(), now.Add(-time.Second), now.Add(time.Second), 1))
 	require.Len(t, events, 4)
 	writers := []*Service{a, b}
 	if writers[1].config.WriterID < writers[0].config.WriterID {
@@ -76,7 +76,7 @@ func TestWarmQuery(t *testing.T) {
 	defer service.Close()
 
 	require.NoError(t, service.Log(`{"value":1}`, 1, 2))
-	events := collectEvents(t, service.Query(context.Background(), now, now, 1, 2))
+	events := collectEvents(t, service.Scan(context.Background(), now, now, 1, 2))
 	require.Len(t, events, 1)
 	require.Equal(t, events[0].Bytes(), []byte(events[0].JSON()))
 	clone := events[0].Clone()
@@ -99,7 +99,7 @@ func TestCloseRetry(t *testing.T) {
 	require.NoError(t, service.Sync(context.Background()))
 
 	now := time.Now()
-	events := collectEvents(t, service.Query(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), 1))
+	events := collectEvents(t, service.Scan(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), 1))
 	require.Equal(t, []string{"one", "two"}, eventTexts(events))
 	require.NoError(t, service.Close())
 }
@@ -118,7 +118,7 @@ func TestAmbiguousCommit(t *testing.T) {
 	manifest, err := service.downloadManifest(context.Background(), dayKey(time.Now()), service.config.WriterID)
 	require.NoError(t, err)
 	require.Len(t, manifest.Chunks, 1)
-	events := collectEvents(t, service.Query(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1))
+	events := collectEvents(t, service.Scan(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1))
 	require.Equal(t, []string{"once"}, eventTexts(events))
 }
 
@@ -138,7 +138,7 @@ func TestWarmSnapshot(t *testing.T) {
 	done := make(chan queryResult, 1)
 	go func() {
 		var result queryResult
-		for event, err := range service.Query(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1) {
+		for event, err := range service.Scan(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1) {
 			if err != nil {
 				result.err = err
 				break
@@ -162,9 +162,9 @@ func TestDiscoveryCache(t *testing.T) {
 	require.NoError(t, service.Log("one", 1))
 	require.NoError(t, service.Sync(context.Background()))
 	from, to := time.Now().Add(-time.Hour), time.Now().Add(time.Hour)
-	collectEvents(t, service.Query(context.Background(), from, to, 1))
+	collectEvents(t, service.Scan(context.Background(), from, to, 1))
 	lists := countMethod(server, "GET", "writers")
-	collectEvents(t, service.Query(context.Background(), from, to, 1))
+	collectEvents(t, service.Scan(context.Background(), from, to, 1))
 	require.Equal(t, lists, countMethod(server, "GET", "writers"))
 	require.NoError(t, service.Close())
 }
@@ -183,9 +183,9 @@ func TestCompactionEquivalence(t *testing.T) {
 	service := testService(t, server, "compact", "compactor", func(c *config) { c.now = func() time.Time { return future } })
 	defer service.Close()
 	from, to := old.Add(-time.Hour), old.Add(time.Hour)
-	before := eventTexts(collectEvents(t, service.Query(context.Background(), from, to, 1)))
+	before := eventTexts(collectEvents(t, service.Scan(context.Background(), from, to, 1)))
 	require.NoError(t, service.Compact(context.Background(), old))
-	after := eventTexts(collectEvents(t, service.Query(context.Background(), from, to, 1)))
+	after := eventTexts(collectEvents(t, service.Scan(context.Background(), from, to, 1)))
 	require.Equal(t, before, after)
 	require.True(t, server.ObjectExists("compact/"+keyOfCompactMeta(dayKey(old))))
 	require.NoError(t, service.Compact(context.Background(), old))
@@ -214,7 +214,7 @@ func TestCompactionCommit(t *testing.T) {
 	defer service.Close()
 	require.Error(t, service.Compact(context.Background(), old))
 	require.False(t, server.ObjectExists("commit/"+keyOfCompactMeta(dayKey(old))))
-	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Query(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1))))
+	require.Equal(t, []string{"one"}, eventTexts(collectEvents(t, service.Scan(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1))))
 	client.fail = false
 	require.NoError(t, service.Compact(context.Background(), old))
 }
@@ -265,13 +265,13 @@ func TestServerCopy(t *testing.T) {
 	cleanup := &deleteFailClient{Client: service.s3Client, fail: true}
 	service.s3Client = cleanup
 	require.Error(t, service.Compact(context.Background(), old))
-	require.Len(t, collectEvents(t, service.Query(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1)), 180)
+	require.Len(t, collectEvents(t, service.Scan(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1)), 180)
 	cleanup.fail = false
 	require.NoError(t, service.Compact(context.Background(), old))
 	require.False(t, server.ObjectExists(firstSource))
 	require.True(t, server.ObjectExists(secondSource))
 	require.NoError(t, service.Compact(context.Background(), old))
-	events := collectEvents(t, service.Query(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1))
+	events := collectEvents(t, service.Scan(context.Background(), old.Add(-time.Hour), old.Add(time.Hour), 1))
 	require.Len(t, events, 180)
 }
 
@@ -284,7 +284,7 @@ func TestQueryErrors(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		count := 0
-		for _, err := range service.Query(ctx, time.Now().Add(-time.Hour), time.Now(), 1) {
+		for _, err := range service.Scan(ctx, time.Now().Add(-time.Hour), time.Now(), 1) {
 			require.ErrorIs(t, err, context.Canceled)
 			count++
 		}
@@ -297,7 +297,7 @@ func TestQueryErrors(t *testing.T) {
 		service := testService(t, server, "arguments", "writer")
 		defer service.Close()
 		count := 0
-		for _, err := range service.Query(context.Background(), time.Now(), time.Now().Add(-time.Hour), 1) {
+		for _, err := range service.Scan(context.Background(), time.Now(), time.Now().Add(-time.Hour)) {
 			require.Error(t, err)
 			count++
 		}
@@ -318,7 +318,7 @@ func TestQueryErrors(t *testing.T) {
 		reader := testService(t, server, "malformed", "reader", func(c *config) { c.now = func() time.Time { return now } })
 		defer reader.Close()
 		count := 0
-		for _, err := range reader.Query(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), 1) {
+		for _, err := range reader.Scan(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), 1) {
 			require.Error(t, err)
 			count++
 		}
@@ -367,11 +367,11 @@ func TestLogGuards(t *testing.T) {
 	require.NoError(t, service.Log("two", 1)) // forces flush via accept buffer full path
 	require.NoError(t, service.Sync(context.Background()))
 
-	for _, err := range service.Query(nil, time.Now().Add(-time.Hour), time.Now(), 1) {
+	for _, err := range service.Scan(nil, time.Now().Add(-time.Hour), time.Now(), 1) {
 		require.Error(t, err)
 		break
 	}
-	for _, err := range service.Query(context.Background(), time.Now().Add(-time.Hour), time.Now()) {
+	for _, err := range service.Scan(context.Background(), time.Now().Add(-time.Hour), time.Now()) {
 		require.Error(t, err)
 		break
 	}
@@ -392,7 +392,7 @@ func TestDayRollover(t *testing.T) {
 	require.NoError(t, service.Log("day-two", 1))
 	require.NoError(t, service.Sync(context.Background()))
 
-	events := collectEvents(t, service.Query(context.Background(), now.Add(-time.Hour), current.Add(time.Hour), 1))
+	events := collectEvents(t, service.Scan(context.Background(), now.Add(-time.Hour), current.Add(time.Hour), 1))
 	require.Equal(t, []string{"day-one", "day-two"}, eventTexts(events))
 }
 
@@ -422,7 +422,7 @@ func TestLifecycle(t *testing.T) {
 		},
 		func() {
 			for range 20 {
-				for range service.Query(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1) {
+				for range service.Scan(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), 1) {
 				}
 			}
 		},


### PR DESCRIPTION
## What changed

- replace `Query` with directional `Scan` and bounded `Page`
- infer ascending or descending order from the time-bound order
- add an opaque URL-safe `Cursor` string and `tales.Zero`
- preserve deterministic ordering across writers, chunks, local snapshots, and compaction
- share snapshot acquisition and query machinery between scan and pagination
- update the mock service, examples, README, and benchmark harness

## Impact

This is an intentional breaking query API change. Callers can stream all matching events with `Scan`, or request cursor-based pages with `Page`. Cursors are exclusive and must be reused with the same bounds and actors.

The cursor encodes the 20-byte stable ordering key as 27-character unpadded base64url:

- 8-byte Unix millisecond timestamp
- 8-byte writer ID
- 4-byte writer-day position

Paging still materializes and sorts at most one matching UTC day at a time.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Go test-lint
- `git diff --check`
- `go run ./cmd/bench`
